### PR TITLE
Sanitycheck handarmparam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
+hybrid_automaton.xml
+output_ha.sh
 *~
 *pyc
+.idea/

--- a/ec_grasp_planner/data/object_param.yaml
+++ b/ec_grasp_planner/data/object_param.yaml
@@ -12,7 +12,7 @@
     EdgeGrasp: {'success': 0}
   netbag:
     SurfaceGrasp: {'success': 0, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
-    WallGrasp: {'success': 1, 'min': [0, 0], 'max': [0, 0]}
+    WallGrasp: {'success': 1, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.042]}
     EdgeGrasp: {'success': 0}
   punnet:
     SurfaceGrasp: {'success': 0.5, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}

--- a/ec_grasp_planner/data/object_param.yaml
+++ b/ec_grasp_planner/data/object_param.yaml
@@ -1,48 +1,48 @@
   apple:
-    SurfaceGrasp: {'success': 1}
-    WallGrasp: {'success': 1}
+    SurfaceGrasp: {'success': 1, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
+    WallGrasp: {'success': 1, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
     EdgeGrasp: {'success': 0}
   mango:
-    SurfaceGrasp: {'success': 1}
-    WallGrasp: {'success': 1}
+    SurfaceGrasp: {'success': 1,'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
+    WallGrasp: {'success': 1, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
     EdgeGrasp: {'success': 0}
   cucumber:
-    SurfaceGrasp: {'success': 1}
-    WallGrasp: {'success': [1, 0.8, 0.7, 0] , 'angle': [0, 180, 360], 'epsilon': 20}
+    SurfaceGrasp: {'success': 1, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
+    WallGrasp: {'success': [1, 0.8, 0.7, 0] , 'angle': [0, 180, 360], 'epsilon': 20, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
     EdgeGrasp: {'success': 0}
   netbag:
-    SurfaceGrasp: {'success': 0}
-    WallGrasp: {'success': 1}
+    SurfaceGrasp: {'success': 0, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
+    WallGrasp: {'success': 1, 'min': [0, 0], 'max': [0, 0]}
     EdgeGrasp: {'success': 0}
   punnet:
-    SurfaceGrasp: {'success': 0.5}
-    WallGrasp: {'success': [0.8, 0.8, 0], 'angle': [0, 180, 360] , 'epsilon': 20}
+    SurfaceGrasp: {'success': 0.5, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
+    WallGrasp: {'success': [0.8, 0.8, 0], 'angle': [0, 180, 360] , 'epsilon': 20, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
     EdgeGrasp: {'success': 1}
   lettuce:
-    SurfaceGrasp: {'success':1}
-    WallGrasp: {'success': 0.5}
+    SurfaceGrasp: {'success': 1, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
+    WallGrasp: {'success': 0.5, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
     EdgeGrasp: {'success': 0.25}
   banana:
-    SurfaceGrasp: {'success': 1}
-    WallGrasp: {'success': 1}
+    SurfaceGrasp: {'success': 1,'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
+    WallGrasp: {'success': 1, 'min': [0, 0], 'max': [0, 0]}
     EdgeGrasp: {'success': 0}
   bottle:
-    SurfaceGrasp: {'success': 1}
-    WallGrasp: {'success': [1, 0.8, 0.7, 0] , 'angle': [0, 180, 360], 'epsilon': 20}
+    SurfaceGrasp: {'success': 1, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
+    WallGrasp: {'success': [1, 0.8, 0.7, 0] , 'angle': [0, 180, 360], 'epsilon': 20, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
     EdgeGrasp: {'success': 0}
   egg:
-    SurfaceGrasp: {'success': 0}
-    WallGrasp: {'success': 1}
+    SurfaceGrasp: {'success': 0, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
+    WallGrasp: {'success': 1, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
     EdgeGrasp: {'success': 0}
   ticket:
-    SurfaceGrasp: {'success': 0}
-    WallGrasp: {'success': 0}
+    SurfaceGrasp: {'success': 0, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
+    WallGrasp: {'success': 0, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
     EdgeGrasp: {'success': 1}
   headband:
-    SurfaceGrasp: {'success':1}
-    WallGrasp: {'success': 0.5}
+    SurfaceGrasp: {'success': 1, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
+    WallGrasp: {'success': 0.5, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
     EdgeGrasp: {'success': 0.5}
   plushtoy:
-    SurfaceGrasp: {'success': 1}
-    WallGrasp: {'success': 1}
+    SurfaceGrasp: {'success': 1, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
+    WallGrasp: {'success': 1, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
     EdgeGrasp: {'success': 1}

--- a/ec_grasp_planner/src/handarm_parameters.py
+++ b/ec_grasp_planner/src/handarm_parameters.py
@@ -86,7 +86,7 @@ class RBOHandP24WAM(RBOHand2):
 
         #drop configuration - this is system specific!
         self['surface_grasp']['object']['drop_off_config'] = np.array(
-            [0.400302, 0.690255, 0.00661675, 2.08453, -0.0533508, -0.267344, 0.626538])
+            [-0.57148, 0.816213, -0.365673, 1.53765, 0.30308, 0.128965, 1.02467])
 
         #synergy type for soft hand closing
         self['surface_grasp']['object']['hand_closing_synergy'] = 1
@@ -96,7 +96,7 @@ class RBOHandP24WAM(RBOHand2):
 
         # time of soft hand closing
         self['surface_grasp']['object']['down_speed'] = 0.35
-        self['surface_grasp']['object']['up_speed'] = 0.35
+        self['surface_grasp']['object']['up_speed'] = 0.409
         self['surface_grasp']['object']['go_down_velocity'] = np.array(
             [0.125, 0.09])  # first value: rotational, second translational
         self['surface_grasp']['object']['pre_grasp_velocity'] = np.array([0.125, 0.08])
@@ -128,7 +128,7 @@ class RBOHandP24WAM(RBOHand2):
         # - fingers pointing downwards
         # - palm facing the object and wall
         self['wall_grasp']['object']['pre_approach_transform'] = tra.concatenate_matrices(
-                tra.translation_matrix([-0.23, 0, -0.15]), #23 cm above object, 15 cm behind
+                tra.translation_matrix([-0.23, 0, -0.18]), #23 cm above object, 15 cm behind
                 tra.concatenate_matrices(
                     tra.rotation_matrix(
                         math.radians(0.), [1, 0, 0]),
@@ -146,12 +146,12 @@ class RBOHandP24WAM(RBOHand2):
 
         # drop configuration - this is system specific!
         self['wall_grasp']['object']['drop_off_config'] = np.array(
-            [0.25118, 0.649543, -0.140991, 1.79668, 0.0720235, 0.453135, -1.03957])
+            [-0.318009, 0.980688, -0.538178, 1.67298, -2.07823, 0.515781, -0.515471])
 
         self['wall_grasp']['object']['table_force'] = 1.8
         self['wall_grasp']['object']['lift_dist'] = 0.1 #short lift after initial contact (before slide)
         self['wall_grasp']['object']['sliding_dist'] = 0.4 #sliding distance, should be min. half Ifco size
-        self['wall_grasp']['object']['up_dist'] = 0.2
+        self['wall_grasp']['object']['up_dist'] = 0.25
         self['wall_grasp']['object']['down_dist'] = 0.25
         self['wall_grasp']['object']['go_down_velocity'] = np.array([0.125, 0.09]) #first value: rotational, second translational
         self['wall_grasp']['object']['slide_velocity'] = np.array([0.125, 0.12])
@@ -268,3 +268,19 @@ class RBOHandP24_pulpyWAM(RBOHandP24WAM):
 
         self['surface_grasp']['mango']['pregrasp_transform'] = tra.concatenate_matrices(
             tra.translation_matrix([-0.03, 0.0, 0.0]), tra.rotation_matrix(math.radians(35.0), [0, 1, 0])) # <-- best so far
+
+
+        self['wall_grasp']['mango'] = self['wall_grasp']['object'].copy()
+        self['wall_grasp']['mango']['wall_force'] = 17.0
+        self['wall_grasp']['cucumber'] = self['wall_grasp']['object'].copy()
+        self['wall_grasp']['cucumber']['wall_force'] = 17.0
+        self['wall_grasp']['cucumber']['pre_approach_transform'] = tra.concatenate_matrices(
+            tra.translation_matrix([-0.23, 0, -0.18]), #23 cm above object, 15 cm behind
+            tra.concatenate_matrices(
+                tra.rotation_matrix(
+                    math.radians(0.), [1, 0, 0]),
+                tra.rotation_matrix(
+                    math.radians(10.0), [0, 1, 0]), #hand rotated 30 degrees on y = thumb axis
+                tra.rotation_matrix(                #this makes the fingers point downwards
+                    math.radians(0.0), [0, 0, 1]),
+            ))

--- a/ec_grasp_planner/src/handarm_parameters.py
+++ b/ec_grasp_planner/src/handarm_parameters.py
@@ -54,7 +54,8 @@ class RBOHandP24WAM(RBOHand2):
         # you can define a default strategy for all objects by setting the second field to  'object'
         # for object-specific strategies set it to the object label
 
-        # transformation (only rotation) between object frame and hand palm frame
+        # transformation between object frame and hand palm frame above the object- should not be changed per object
+        # please don't set x and y position, this should be done in pre_grasp_transform
         # the convention at our lab is: x along the fingers and z normal on the palm.
         # please follow the same convention
         self['surface_grasp']['object']['hand_transform'] = tra.concatenate_matrices(tra.translation_matrix([0.0, 0.0, 0.3]),
@@ -64,16 +65,12 @@ class RBOHandP24WAM(RBOHand2):
                                                                                     tra.rotation_matrix(
                                                                                         math.radians(180.), [1, 0, 0])))
 
-        # above the object, in hand palm frame
+        # position of hand relative to the object before and at grasping
         self['surface_grasp']['object']['pregrasp_transform'] = tra.concatenate_matrices(
-            tra.translation_matrix([-0.05, 0.0, 0.0]), tra.rotation_matrix(math.radians(10.0), [0, 1, 0]))
+            tra.translation_matrix([0.0, 0.0, 0.0]), tra.rotation_matrix(math.radians(10.0), [0, 1, 0]))
 
-        # at grasp position, in hand palm frame TODO is that used somewhere?
-        self['surface_grasp']['object']['grasp_transform'] = tra.concatenate_matrices(tra.translation_matrix([-0.03, -0.04, 0.05]),
-                                                                                 tra.rotation_matrix(math.radians(30.0),
-                                                                                                     [0, 1, 0]))
 
-        # first motion after grasp, in hand palm frame only rotation
+        # first motion after grasp, in hand palm frame
         self['surface_grasp']['object']['post_grasp_transform'] = tra.concatenate_matrices(
             tra.translation_matrix([0.0, 0.0, 0.0]),
             tra.rotation_matrix(math.radians(-15.),
@@ -85,12 +82,11 @@ class RBOHandP24WAM(RBOHand2):
                                                                                                 [0, 1, 0]))
 
         # the maximum allowed force for pushing down
-        self['surface_grasp']['object']['downward_force'] = 4 # might be +10/-7 ??
+        self['surface_grasp']['object']['downward_force'] = 4
 
         #drop configuration - this is system specific!
         self['surface_grasp']['object']['drop_off_config'] = np.array(
             [0.400302, 0.690255, 0.00661675, 2.08453, -0.0533508, -0.267344, 0.626538])
-            #[0.600302, 0.690255, 0.00661675, 2.08453, -0.0533508, -0.267344, 0.626538])
 
         #synergy type for soft hand closing
         self['surface_grasp']['object']['hand_closing_synergy'] = 1
@@ -103,8 +99,7 @@ class RBOHandP24WAM(RBOHand2):
         self['surface_grasp']['object']['up_speed'] = 0.35
         self['surface_grasp']['object']['go_down_velocity'] = np.array(
             [0.125, 0.09])  # first value: rotational, second translational
-        self['surface_grasp']['object']['pre_grasp_velocity'] = np.array([0.125, 0.08]) # more helpful would be joint velocities, not EE
-
+        self['surface_grasp']['object']['pre_grasp_velocity'] = np.array([0.125, 0.08])
 
 
         #####################################################################################
@@ -241,7 +236,7 @@ class RBOHandP24_pulpyWAM(RBOHandP24WAM):
         # object specific parameters for apple
         self['surface_grasp']['apple'] = self['surface_grasp']['object'].copy()
         self['surface_grasp']['apple']['pregrasp_transform'] = tra.concatenate_matrices(
-            tra.translation_matrix([0.0, 0, 0.0]), tra.rotation_matrix(math.radians(20.0), [0, 1, 0]))
+            tra.translation_matrix([0.0, 0.0, 0.0]), tra.rotation_matrix(math.radians(25.0), [0, 1, 0])) # tested for DEMO
 
         # object specific parameters for cucumber
         self['surface_grasp']['cucumber'] = self['surface_grasp']['object'].copy()
@@ -257,10 +252,7 @@ class RBOHandP24_pulpyWAM(RBOHandP24WAM):
         self['surface_grasp']['punnet']['pre_grasp_velocity'] = np.array([0.12, 0.06])
 
         self['surface_grasp']['punnet']['pregrasp_transform'] = tra.concatenate_matrices(
-            #tra.translation_matrix([-0.09, 0, -0.0]), tra.rotation_matrix(math.radians(40.0), [0, 1, 0])) #okayish ... one success
-            #tra.translation_matrix([-0.1, -0.04, -0.0]), tra.rotation_matrix(math.radians(45.0), [0, 1, 0]))
             tra.translation_matrix([-0.1, -0.02, -0.0]), tra.rotation_matrix(math.radians(35.0), [0, 1, 0])) # <-- best so far
-            #tra.translation_matrix([-0.09, -0.02, -0.0]), tra.rotation_matrix(math.radians(35.0), [0, 1, 0]))
 
         self['surface_grasp']['punnet']['downward_force'] = 10  # important, as it helps to fix the object and allows
         # the hand to wrap around the punnet such that it is stable. With lower values the grasps were almost always all
@@ -270,3 +262,9 @@ class RBOHandP24_pulpyWAM(RBOHandP24WAM):
             tra.translation_matrix([0.0, 0.0, -0.0]),
             tra.rotation_matrix(math.radians(0.), [0, 1, 0]))
             #tra.rotation_matrix(math.radians(10.), [1, 0, 0]))
+
+        # object specific parameters for punnet
+        self['surface_grasp']['mango'] = self['surface_grasp']['object'].copy()
+
+        self['surface_grasp']['mango']['pregrasp_transform'] = tra.concatenate_matrices(
+            tra.translation_matrix([-0.03, 0.0, 0.0]), tra.rotation_matrix(math.radians(35.0), [0, 1, 0])) # <-- best so far

--- a/ec_grasp_planner/src/handarm_parameters.py
+++ b/ec_grasp_planner/src/handarm_parameters.py
@@ -102,7 +102,7 @@ class RBOHandP24WAM(RBOHand2):
         self['surface_grasp']['object']['down_speed'] = 0.35
         self['surface_grasp']['object']['up_speed'] = 0.35
         self['surface_grasp']['object']['go_down_velocity'] = np.array(
-            [0.125, 0.06])  # first value: rotational, second translational
+            [0.125, 0.09])  # first value: rotational, second translational
         self['surface_grasp']['object']['pre_grasp_velocity'] = np.array([0.125, 0.08]) # more helpful would be joint velocities, not EE
 
 
@@ -158,7 +158,7 @@ class RBOHandP24WAM(RBOHand2):
         self['wall_grasp']['object']['sliding_dist'] = 0.4 #sliding distance, should be min. half Ifco size
         self['wall_grasp']['object']['up_dist'] = 0.2
         self['wall_grasp']['object']['down_dist'] = 0.25
-        self['wall_grasp']['object']['go_down_velocity'] = np.array([0.125, 0.06]) #first value: rotational, second translational
+        self['wall_grasp']['object']['go_down_velocity'] = np.array([0.125, 0.09]) #first value: rotational, second translational
         self['wall_grasp']['object']['slide_velocity'] = np.array([0.125, 0.12])
         self['wall_grasp']['object']['wall_force'] = 12.0
 

--- a/ec_grasp_planner/src/handarm_parameters.py
+++ b/ec_grasp_planner/src/handarm_parameters.py
@@ -236,7 +236,7 @@ class RBOHandP24_pulpyWAM(RBOHandP24WAM):
         # object specific parameters for apple
         self['surface_grasp']['apple'] = self['surface_grasp']['object'].copy()
         self['surface_grasp']['apple']['pregrasp_transform'] = tra.concatenate_matrices(
-            tra.translation_matrix([0.0, 0.0, 0.0]), tra.rotation_matrix(math.radians(25.0), [0, 1, 0])) # tested for DEMO
+            tra.translation_matrix([0.0, 0.0, 0.0]), tra.rotation_matrix(math.radians(25.0), [0, 1, 0]))
 
         # object specific parameters for cucumber
         self['surface_grasp']['cucumber'] = self['surface_grasp']['object'].copy()

--- a/ec_grasp_planner/src/handarm_parameters.py
+++ b/ec_grasp_planner/src/handarm_parameters.py
@@ -110,7 +110,7 @@ class RBOHandP24WAM(RBOHand2):
         #####################################################################################
         # below are parameters for wall grasp with P24 fingers (standard RBO hand)
         #####################################################################################
-        self['wall_grasp']['object']['hand_closing_duration'] = 5
+        self['wall_grasp']['object']['hand_closing_duration'] = 1.0
         self['wall_grasp']['object']['initial_goal'] = np.array(
             [0.439999, 0.624437, -0.218715, 1.71695, -0.735594, 0.197093, -0.920799])
 
@@ -138,29 +138,29 @@ class RBOHandP24WAM(RBOHand2):
                     tra.rotation_matrix(
                         math.radians(0.), [1, 0, 0]),
                     tra.rotation_matrix(
-                        math.radians(30.0), [0, 1, 0]), #hand rotated 30 degrees on y = thumb axis
+                        math.radians(15.0), [0, 1, 0]), #hand rotated 30 degrees on y = thumb axis
                     tra.rotation_matrix(                #this makes the fingers point downwards
                         math.radians(0.0), [0, 0, 1]),
             ))
 
         # first motion after grasp, in hand palm frame
         self['wall_grasp']['object']['post_grasp_transform'] = tra.concatenate_matrices(
-            tra.translation_matrix([0.0, 0.0, 0.0]), #nothing right now
-            tra.rotation_matrix(math.radians(0.0),
+            tra.translation_matrix([-0.05, 0.0, 0.0]), #nothing right now
+            tra.rotation_matrix(math.radians(-25.0),
                                 [0, 1, 0]))
 
         # drop configuration - this is system specific!
         self['wall_grasp']['object']['drop_off_config'] = np.array(
             [0.25118, 0.649543, -0.140991, 1.79668, 0.0720235, 0.453135, -1.03957])
 
-        self['wall_grasp']['object']['table_force'] = 1.5
+        self['wall_grasp']['object']['table_force'] = 1.8
         self['wall_grasp']['object']['lift_dist'] = 0.1 #short lift after initial contact (before slide)
         self['wall_grasp']['object']['sliding_dist'] = 0.4 #sliding distance, should be min. half Ifco size
         self['wall_grasp']['object']['up_dist'] = 0.2
         self['wall_grasp']['object']['down_dist'] = 0.25
         self['wall_grasp']['object']['go_down_velocity'] = np.array([0.125, 0.06]) #first value: rotational, second translational
-        self['wall_grasp']['object']['slide_velocity'] = np.array([0.125, 0.06])
-        self['wall_grasp']['object']['wall_force'] = 3.0
+        self['wall_grasp']['object']['slide_velocity'] = np.array([0.125, 0.12])
+        self['wall_grasp']['object']['wall_force'] = 12.0
 
 
 class RBOHandP11WAM(RBOHandP24WAM):

--- a/ec_grasp_planner/src/handarm_parameters.py
+++ b/ec_grasp_planner/src/handarm_parameters.py
@@ -241,7 +241,7 @@ class RBOHandP24_pulpyWAM(RBOHandP24WAM):
         # object specific parameters for cucumber
         self['surface_grasp']['cucumber'] = self['surface_grasp']['object'].copy()
         self['surface_grasp']['cucumber']['pregrasp_transform'] = tra.concatenate_matrices(
-            tra.translation_matrix([-0.09, 0, 0.0]), tra.rotation_matrix(math.radians(40.0), [0, 1, 0]))
+            tra.translation_matrix([-0.045, 0, 0.0]), tra.rotation_matrix(math.radians(40.0), [0, 1, 0]))
 
         self['surface_grasp']['cucumber']['post_grasp_transform'] = tra.concatenate_matrices(
             tra.translation_matrix([0.0, 0.0, -0.14]),
@@ -268,19 +268,3 @@ class RBOHandP24_pulpyWAM(RBOHandP24WAM):
 
         self['surface_grasp']['mango']['pregrasp_transform'] = tra.concatenate_matrices(
             tra.translation_matrix([-0.03, 0.0, 0.0]), tra.rotation_matrix(math.radians(35.0), [0, 1, 0])) # <-- best so far
-
-
-        self['wall_grasp']['mango'] = self['wall_grasp']['object'].copy()
-        self['wall_grasp']['mango']['wall_force'] = 17.0
-        self['wall_grasp']['cucumber'] = self['wall_grasp']['object'].copy()
-        self['wall_grasp']['cucumber']['wall_force'] = 17.0
-        self['wall_grasp']['cucumber']['pre_approach_transform'] = tra.concatenate_matrices(
-            tra.translation_matrix([-0.23, 0, -0.18]), #23 cm above object, 15 cm behind
-            tra.concatenate_matrices(
-                tra.rotation_matrix(
-                    math.radians(0.), [1, 0, 0]),
-                tra.rotation_matrix(
-                    math.radians(10.0), [0, 1, 0]), #hand rotated 30 degrees on y = thumb axis
-                tra.rotation_matrix(                #this makes the fingers point downwards
-                    math.radians(0.0), [0, 0, 1]),
-            ))

--- a/ec_grasp_planner/src/handarm_parameters.py
+++ b/ec_grasp_planner/src/handarm_parameters.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import math
+import itertools
 import numpy as np
 from tf import transformations as tra
 
@@ -30,6 +31,23 @@ class BaseHandArm(dict):
 
 
         self['isForceControllerAvailable'] = False
+
+    def checkValidity(self):
+        # This function should always be called after the constructor of any class inherited from BaseHandArm
+        # This convenience function allows to combine multiple sanity checks to ensure the handarm_parameters are as intended.
+        self.assertNoCopyMissing()
+
+    def assertNoCopyMissing(self):
+        strategies = ['wall_grasp','edge_grasp','surface_grasp']
+        for s, s_other in itertools.product(strategies, repeat=2):
+            for k in self[s]:
+                for k_other in self[s_other]:
+                    if not k_other == k and self[s][k] is self[s_other][k_other]:
+                        # unitended reference copy of dictionary.
+                        # This probably means that some previously defined parameters were overwritten.
+                        raise AssertionError("You probably forgot to call copy(): {0} and {1} are equal for {2}".format(
+                            k,k_other,s))
+
 
 
 class RBOHand2(BaseHandArm):

--- a/ec_grasp_planner/src/multi_object_params.py
+++ b/ec_grasp_planner/src/multi_object_params.py
@@ -103,8 +103,10 @@ class multi_object_params:
         object_params = self.data[object['type']][strategy]
         object_params['frame'] = object['frame']
         q_val = 1
-        q_val = q_val * self.pdf_object_strategy(object_params) * self.pdf_object_ec(object_params, ec_frame, strategy)
-        # print(" ** q_val = {}".format(q_val))
+        pdf_o_e = self.pdf_object_ec(object_params, ec_frame, strategy)
+        pdf_o_s = self.pdf_object_strategy(object_params)
+        q_val = q_val * pdf_o_s * pdf_o_e
+        print(" ** strategy={}, q_val = {}, object, ec={}, obj_strategy={}".format(strategy, q_val, pdf_o_e, pdf_o_s))
         return q_val
 
 ## --------------------------------------------------------- ##
@@ -113,7 +115,7 @@ class multi_object_params:
         # find max probablity in list
 
         ideces_of_max = np.argwhere(Q_matrix == Q_matrix.max())
-        # print("ideces_of_max  = {}".format(ideces_of_max ))
+        print("ideces_of_max  = {}".format(ideces_of_max ))
 
         return ideces_of_max[0][0], ideces_of_max[0][1]
 
@@ -196,7 +198,8 @@ class multi_object_params:
         #argmax samples from the [max (H(obj, ec)] list
         if h_process_type == "Deterministic":
             object_index,  ec_index = self.argmax_h(Q_matrix)
-            # print(" ** h_mx[{}, {}]".format(object_index, ec_index))
+            print(" ** h_mx[{}, {}]".format(object_index, ec_index))
+            print(" ** h_mx[{}, {}]".format(object_index, ecs[ec_index]))
             return objects[object_index], ecs[ec_index]
         # samples from [H(obj, ec)] list
         elif h_process_type == "Probabilistic":

--- a/ec_grasp_planner/src/multi_object_params.py
+++ b/ec_grasp_planner/src/multi_object_params.py
@@ -130,7 +130,7 @@ class multi_object_params:
         q_val = q_val * \
                 self.pdf_object_strategy(object_params) * \
                 self.pdf_object_ec(object_params, ec_frame, strategy) * \
-                self.black_list_walls(current_ec_index, all_ec_frames) if (strategy=="WallGrasp") else 1
+                self.black_list_walls(current_ec_index, all_ec_frames) if (strategy in ["WallGrasp", "EdgeGrasp"]) else 1
 
 
         # print(" ** q_val = {} blaklisted={}".format(q_val, self.black_list_walls(current_ec_index, all_ec_frames)))

--- a/ec_grasp_planner/src/planner.py
+++ b/ec_grasp_planner/src/planner.py
@@ -158,11 +158,18 @@ class GraspPlanner():
         self.tf_listener.waitForTransform(robot_base_frame, graph.header.frame_id, time, rospy.Duration(2.0))
         graph_in_base_transform = self.tf_listener.asMatrix(robot_base_frame, graph.header)
 
+        self.tf_listener.waitForTransform('ifco', robot_base_frame, time, rospy.Duration(2.0))
+        (ifco_in_base_translation, ifco_in_base_rot) = self.tf_listener.lookupTransform('ifco', robot_base_frame, rospy.Time(0)) #transform_msg_to_homogenous_tf()
+        tf_transformer = tf.TransformerROS()
+        ifco_in_base_transform = tf_transformer.fromTranslationRotation(ifco_in_base_translation, ifco_in_base_rot)
+        print ifco_in_base_transform
+
 
         # we assume that all objects are on the same plane, so all EC can be exploited for any of the objects
         (chosen_object, chosen_node) = self.multi_object_handler.process_objects_ecs(object_list,
                                                                                      node_list,
                                                                                      graph_in_base_transform,
+                                                                                     ifco_in_base_transform,
                                                                                      req.object_heuristic_function
                                                                                      )
         # print(" * object type: {}, ec type: {}, heuristc funciton type: {}".format(chosen_object['type'], chosen_node.label, req.object_heuristic_function))
@@ -261,6 +268,8 @@ def create_surface_grasp(object_frame, support_surface_frame, handarm_params, ob
     # Set the directions to use TRIK controller with
     dirDown = tra.translation_matrix([0, 0, -down_speed]);
     dirUp = tra.translation_matrix([0, 0, up_speed]);
+
+
 
     # Set the frames to visualize with RViz
     rviz_frames = []
@@ -415,10 +424,9 @@ def create_wall_grasp(object_frame, support_surface_frame, wall_frame, handarm_p
 
 
     # Rviz debug frames
-    rviz_frames.append(wall_frame)
-    rviz_frames.append(ec_frame)
-    #rviz_frames.append(position_behind_object)
     rviz_frames.append(pre_approach_pose)
+    rviz_frames.append(ec_frame)
+    rviz_frames.append(wall_frame)
 
     # use the default synergy
     hand_synergy = 1

--- a/ec_grasp_planner/src/planner.py
+++ b/ec_grasp_planner/src/planner.py
@@ -103,11 +103,13 @@ class GraspPlanner():
         self.handarm_params = handarm_parameters.__dict__[req.handarm_type]()
 
         try:
+            print('Wait for vision service')
             rospy.wait_for_service('compute_ec_graph', timeout=30)
         except rospy.ROSException as e:
             raise rospy.ServiceException("Vision service call unavailable: %s" % e)
 
         try:
+            print('Call vision service now...!')
             call_vision = rospy.ServiceProxy('compute_ec_graph', vision_srv.ComputeECGraph)
             res = call_vision(self.object_type)
             graph = res.graph

--- a/ec_grasp_planner/src/planner.py
+++ b/ec_grasp_planner/src/planner.py
@@ -89,11 +89,13 @@ class GraspPlanner():
         # Check for bad service parameters (we don't have to check for object since we always have a default 'object')
         grasp_choices = ["Any", "WallGrasp", "SurfaceGrasp", "EdgeGrasp"]
         if self.grasp_type not in grasp_choices:
-            raise rospy.ServiceException("grasp_type not supported. Choose from {0}".format(grasp_choices))
+            raise rospy.ServiceException("grasp_type {0} not supported. Choose from {1}".format(self.grasp_type,
+                                                                                                grasp_choices))
 
         heuristic_choices = ["Deterministic", "Probabilistic", "Random"]
         if req.object_heuristic_function not in heuristic_choices:
-            raise rospy.ServiceException("heuristic not supported. Choose from {0}".format(heuristic_choices))
+            raise rospy.ServiceException("heuristic {0} not supported. Choose from {1}".format(req.object_heuristi,
+                                                                                               heuristic_choices))
 
         if req.handarm_type not in handarm_parameters.__dict__:
             raise rospy.ServiceException("handarm type not supported. Did you add {0} to handarm_parameters.py".format(
@@ -101,6 +103,8 @@ class GraspPlanner():
 
 
         self.handarm_params = handarm_parameters.__dict__[req.handarm_type]()
+        # check if the handarm parameters aren't containing any contradicting information or bugs because of non-copying
+        self.handarm_params.checkValidity()
 
         try:
             print('Wait for vision service')


### PR DESCRIPTION
This PR will mitigate the danger of issue #33 
By calling `checkValidity()` after creating an handarm_paramter object it is ensured that an exception is thrown in case a copy() was forgotten.
This does not check for a copy paste error in the strategy section, like 
```python
self['wall_grasp']['mango'] = self['surface_grasp']['object'].copy()
``` 
However, the call for `copy()` is checked
A way to prevent this and the issue #33 would be to introduce a convenient function like this:
```python
 def copyFromGenericObject(self, strategy, object):
        self[strategy][object] = self[strategy]['object'].copy()
```
which would be called like this
```python
self.copyFromGenericObject('surface_grasp', 'mango')
```
If you think this might be useful as well, I can add it to this PR.

### IMPORTANT: This PR should not be merged before #34 
I based this branch on the wall_grasp_tuning_DEMO branch, which is not merged yet to prevent merge conflicts. Merging this will also merge all the other changes to master.
My suggestion is, to merge #34, tag the state, and then merge this PR into master.