### PR TITLE
Grasp success estimator

### DIFF
--- a/ec_grasp_planner/data/object_param.yaml
+++ b/ec_grasp_planner/data/object_param.yaml
@@ -32,7 +32,7 @@
         mass_estimation_no_object: REPLAN
         mass_estimation_too_many: REPLAN
     EdgeGrasp: {'success': 0}
-    mass: {'mean': 0.2, 'stddev': 0.05} # artificial values, since no fake mangos available. TODO get params as soon as we have the fake mangos again!
+    mass: {'mean': 0.28052, 'stddev': 0.05958} # artificial values, since no fake mangos available. TODO get params as soon as we have the fake mangos again!
 
   cucumber:
     SurfaceGrasp: 

--- a/ec_grasp_planner/data/object_param.yaml
+++ b/ec_grasp_planner/data/object_param.yaml
@@ -2,6 +2,7 @@
     SurfaceGrasp: {'success': 1, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
     WallGrasp: {'success': 1, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
     EdgeGrasp: {'success': 0}
+    mass: {'mean': 0.28052, 'stddev': 0.05958} # values for fake apples (with small EE/FT noise)
   mango:
     SurfaceGrasp: {'success': 1,'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
     WallGrasp: {'success': 1, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
@@ -15,7 +16,7 @@
     SurfaceGrasp: {'success': 0, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
     WallGrasp: {'success': 1, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.042]}
     EdgeGrasp: {'success': 0}
-    mass: {'mean': 0.193, 'stddev': 0.02281} # values for fake lime netbags
+    mass: {'mean': 0.28051, 'stddev': 0.05958} # values for fake lime netbags (with small EE/FT noise)
   punnet:
     SurfaceGrasp: {'success': 0.5, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
     WallGrasp: {'success': [0.8, 0.8, 0], 'angle': [0, 180, 360] , 'epsilon': 20, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}

--- a/ec_grasp_planner/data/object_param.yaml
+++ b/ec_grasp_planner/data/object_param.yaml
@@ -10,14 +10,17 @@
     SurfaceGrasp: {'success': 1, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
     WallGrasp: {'success': [1, 0.8, 0.7, 0] , 'angle': [0, 180, 360], 'epsilon': 20, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
     EdgeGrasp: {'success': 0}
+    mass: {'mean': 0.07058, 'stddev': 0.00359} # values for fake cucumbers
   netbag:
     SurfaceGrasp: {'success': 0, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
     WallGrasp: {'success': 1, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.042]}
     EdgeGrasp: {'success': 0}
+    mass: {'mean': 0.193, 'stddev': 0.02281} # values for fake lime netbags
   punnet:
     SurfaceGrasp: {'success': 0.5, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
     WallGrasp: {'success': [0.8, 0.8, 0], 'angle': [0, 180, 360] , 'epsilon': 20, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
     EdgeGrasp: {'success': 1}
+    mass: {'mean': 0.23008, 'stddev': 0.00395} # values for fake new punnets
   lettuce:
     SurfaceGrasp: {'success': 1, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
     WallGrasp: {'success': 0.5, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}

--- a/ec_grasp_planner/data/object_param.yaml
+++ b/ec_grasp_planner/data/object_param.yaml
@@ -1,33 +1,116 @@
   apple:
-    SurfaceGrasp: {'success': 1, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
-    WallGrasp: {'success': 1, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
+    SurfaceGrasp: 
+      success: 1.0
+      min: [-0.14, -0.1]
+      max: [0.14, 0.05]
+      reactions: 
+        mass_estimation_no_object: REPLAN
+        mass_estimation_too_many: REPLAN
+    WallGrasp: 
+      success: 1.0
+      min: [-1000.0, -0.075]
+      max: [-0.05, 0.045]
+      reactions: 
+        mass_estimation_no_object: REPLAN
+        mass_estimation_too_many: REPLAN
     EdgeGrasp: {'success': 0}
     mass: {'mean': 0.28052, 'stddev': 0.05958} # values for fake apples (with small EE/FT noise)
+
   mango:
-    SurfaceGrasp: {'success': 1,'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
-    WallGrasp: {'success': 1, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
+    SurfaceGrasp: 
+      success: 1.0
+      min: [-0.14, -0.1]
+      max: [0.14, 0.05]
+      reactions: 
+        mass_estimation_no_object: REPLAN
+        mass_estimation_too_many: REPLAN
+    WallGrasp: 
+      success: 1.0
+      min: [-1000.0, -0.075]
+      max: [-0.05, 0.045]
+      reactions: 
+        mass_estimation_no_object: REPLAN
+        mass_estimation_too_many: REPLAN
     EdgeGrasp: {'success': 0}
-    # No fake mangos present. TODO get params as soon as we have the fake mangos again
+    mass: {'mean': 0.2, 'stddev': 0.05} # artificial values, since no fake mangos available. TODO get params as soon as we have the fake mangos again!
+
   cucumber:
-    SurfaceGrasp: {'success': 1, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
-    WallGrasp: {'success': [1, 0.8, 0.7, 0] , 'angle': [0, 180, 360], 'epsilon': 20, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
+    SurfaceGrasp: 
+      success: 1.0
+      min: [-0.14, -0.1]
+      max: [0.14, 0.05]
+      reactions: 
+        mass_estimation_no_object: REEXECUTE
+        mass_estimation_too_many: REPLAN
+    WallGrasp:
+      success: [1.0, 0.8, 0.7, 0.0]
+      angle: [0, 180, 360]
+      epsilon: 20
+      min: [-1000.0, -0.075]
+      max: [-0.05, 0.045]
+      reactions: 
+        mass_estimation_no_object: REEXECUTE
+        mass_estimation_too_many: REPLAN
     EdgeGrasp: {'success': 0}
     mass: {'mean': 0.07058, 'stddev': 0.00359} # values for fake cucumbers
+
+
   netbag:
-    SurfaceGrasp: {'success': 0, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
-    WallGrasp: {'success': 1, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.042]}
+    SurfaceGrasp:
+      success: 0.0
+      min: [-0.14, -0.1]
+      max: [0.14, 0.05]
+      reactions: 
+        mass_estimation_no_object: REEXECUTE
+        mass_estimation_too_many: REPLAN
+    WallGrasp:
+      success: 1.0
+      min: [-1000.0, -0.075]
+      max': [-0.05, 0.042]
+      reactions: 
+        mass_estimation_no_object: REEXECUTE
+        mass_estimation_too_many: REPLAN
     EdgeGrasp: {'success': 0}
     mass: {'mean': 0.28051, 'stddev': 0.05958} # values for fake lime netbags (with small EE/FT noise)
+
   punnet:
-    SurfaceGrasp: {'success': 0.5, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
-    WallGrasp: {'success': [0.8, 0.8, 0], 'angle': [0, 180, 360] , 'epsilon': 20, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
+    SurfaceGrasp: 
+      success: 0.5
+      min: [-0.14, -0.1]
+      max: [0.14, 0.05]
+      reactions: 
+        mass_estimation_no_object: REPLAN
+        mass_estimation_too_many: REPLAN
+    WallGrasp:
+      success: [0.8, 0.8, 0.0]
+      angle: [0, 180, 360]
+      epsilon: 20
+      min: [-1000.0, -0.075]
+      max: [-0.05, 0.045]
+      reactions: 
+        mass_estimation_no_object: REPLAN
+        mass_estimation_too_many: REPLAN
     EdgeGrasp: {'success': 1}
     mass: {'mean': 0.23008, 'stddev': 0.00395} # values for fake new punnets
+
   lettuce:
-    SurfaceGrasp: {'success': 1, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
-    WallGrasp: {'success': 0.5, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
+    SurfaceGrasp:
+      success: 1.0
+      min: [-0.14, -0.1]
+      max: [0.14, 0.05]
+      reactions: 
+        mass_estimation_no_object: REEXECUTE
+        mass_estimation_too_many: REPLAN
+    WallGrasp:
+      success: 0.5
+      min: [-1000.0, -0.075]
+      max: [-0.05, 0.045]
+      reactions: 
+        mass_estimation_no_object: REEXECUTE
+        mass_estimation_too_many: REPLAN
     EdgeGrasp: {'success': 0.25}
     mass: {'mean': 0.19341, 'stddev': 0.05560} # values for fake lettuce (with small EE/FT noise)
+
   banana:
     SurfaceGrasp: {'success': 1,'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
     WallGrasp: {'success': 1, 'min': [0, 0], 'max': [0, 0]}

--- a/ec_grasp_planner/data/object_param.yaml
+++ b/ec_grasp_planner/data/object_param.yaml
@@ -7,6 +7,7 @@
     SurfaceGrasp: {'success': 1,'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
     WallGrasp: {'success': 1, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
     EdgeGrasp: {'success': 0}
+    # No fake mangos present. TODO get params as soon as we have the fake mangos again
   cucumber:
     SurfaceGrasp: {'success': 1, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
     WallGrasp: {'success': [1, 0.8, 0.7, 0] , 'angle': [0, 180, 360], 'epsilon': 20, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
@@ -26,6 +27,7 @@
     SurfaceGrasp: {'success': 1, 'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
     WallGrasp: {'success': 0.5, 'min': [-1000.0, -0.075], 'max': [-0.05, 0.045]}
     EdgeGrasp: {'success': 0.25}
+    mass: {'mean': 0.19341, 'stddev': 0.05560} # values for fake lettuce (with small EE/FT noise)
   banana:
     SurfaceGrasp: {'success': 1,'min': [-0.14, -0.1], 'max': [0.14, 0.05]}
     WallGrasp: {'success': 1, 'min': [0, 0], 'max': [0, 0]}

--- a/ec_grasp_planner/src/grasp_success_estimator.py
+++ b/ec_grasp_planner/src/grasp_success_estimator.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python
+
+import yaml
+import rospy
+import tf
+import tf.transformations
+from enum import Enum
+
+# from std_msgs.msg import Int8 <-- Not used anymore since ROSTopicSensor only supports Float64
+from std_msgs.msg import Float64
+from std_msgs.msg import MultiArrayDimension
+from std_msgs.msg import Float64MultiArray
+from geometry_msgs.msg import WrenchStamped
+from hybrid_automaton_msgs.msg import HAMState
+
+from scipy.stats import norm
+
+import sys
+
+
+class RESPONSES(Enum):
+    REFERENCE_MEASUREMENT_SUCCESS = 0.0
+    REFERENCE_MEASUREMENT_FAILURE = 1.0
+
+    ESTIMATION_RESULT_NO_OBJECT = 10.0
+    ESTIMATION_RESULT_OKAY = 11.0
+    ESTIMATION_RESULT_TOO_MANY = 12.0
+    ESTIMATION_RESULT_UNKNOWN_FAILURE = 13.0
+
+    GRASP_SUCCESS_ESTIMATOR_INACTIVE = 99.0
+
+
+class ObjectModel(object):
+    def __init__(self, name, mass_mean, mass_stddev):
+        # The name of the object class (e.g. cucumber)
+        self.name = name
+        # mean of the object masses (e.g. over all cucumbers) in kg
+        self.mass_mean = mass_mean
+        # standard deviation of mass of the object (e.g. over all cucumbers)
+        self.mass_stddev = mass_stddev
+
+
+class MassEstimator(object):
+
+    # If confidence is lower than this threshold the estimator warns that confidence is low (will still report a result)
+    CONFIDENCE_THRESHOLD = 0.3
+
+    # FT-Topic to use. Possible options are: /ft_notool and /ft_sensor_wrench
+    FT_TOPIC = "/ft_notool"
+
+    # standard acceleration due to gravity
+    GRAVITY = 9.806
+
+    @staticmethod
+    def force2mass(f):
+        # F = m * a => F/a = m
+        return f / -MassEstimator.GRAVITY  # We need the negative value since gravity accelerates along negative z-axis
+
+    @staticmethod
+    def load_object_params(path_to_object_parameters):
+        reference_object_info = {}
+        with open(path_to_object_parameters, 'r') as stream:
+            try:
+                data = yaml.load(stream)
+                for o in data:
+                    if 'mass' in data[o]:
+                        reference_object_info[o] = ObjectModel(o, data[o]['mass']['mean'], data[o]['mass']['stddev'])
+                # print("data loaded {}".format(file))
+                return reference_object_info
+            except yaml.YAMLError as exc:
+                print(exc)
+                return None
+
+    @staticmethod
+    def list_to_Float64MultiArrayMsg(l):
+        l_copy = list(l)
+        msg = Float64MultiArray()
+        msg.layout.dim = [MultiArrayDimension(size=len(l_copy))]
+        msg.data = l_copy
+
+        return msg
+
+    def __init__(self, object_ros_param_path, path_to_object_parameters):
+        rospy.init_node('graspSuccessEstimatorMass', anonymous=True)
+
+        self.tf_listener = tf.TransformListener()
+
+        # Stores the last measurement from the ft sensor. # TODO change this to a sliding window?
+        self.last_ft_measurement = None
+        # This is the ft measurement that is used as the empty hand reference. From this one we can calculate change.
+        self.ft_measurement_reference = None
+        # The calculated reference mass in kg.
+        self.reference_mass = None
+        # Object information loaded on node start-up from the provided object parameter file.
+        self.objects_info = MassEstimator.load_object_params(path_to_object_parameters)
+        # The name of the ros parameter than contains the name of the current object (e.g. /planner_gui/object).
+        self.object_ros_param_path = object_ros_param_path
+        # The name of the current object retrieved from ros parameters during reference acquisition and checked
+        # during estimation. Used to access object information (e.g. mass probability distribution).
+        self.current_object_name = rospy.get_param(self.object_ros_param_path, default=None)
+        # subscriber to the ft topic that is used to estimate the weight
+        if MassEstimator.FT_TOPIC == "/ft_sensor_wrench":
+            self.ft_sensor_subscriber = rospy.Subscriber(MassEstimator.FT_TOPIC, WrenchStamped, self.ft_sensor_callback,
+                                                         queue_size=10)
+        else:
+            # assume /ft_notool
+            self.ft_sensor_subscriber = rospy.Subscriber(MassEstimator.FT_TOPIC, Float64MultiArray,
+                                                         self.ft_sensor_no_tool_callback,
+                                                         queue_size=10)
+
+        # Stores the last active control mode to ensure we only start estimation once (the moment we enter the state)
+        self.active_cm = None
+        self.ham_state_subscriber = rospy.Subscriber("/ham_state", HAMState, self.ham_state_callback,
+                                                     queue_size=10)
+
+        self.estimator_status_pub = rospy.Publisher('/graspSuccessEstimator/status', Float64, queue_size=10)
+        self.estimator_number_pub = rospy.Publisher('/graspSuccessEstimator/num_objects', Float64, queue_size=10)
+        self.estimator_confidence_pub = rospy.Publisher('/graspSuccessEstimator/confidence', Float64, queue_size=10)
+        self.estimator_confidence_all_pub = rospy.Publisher('/graspSuccessEstimator/confidence_all', Float64MultiArray,
+                                                            queue_size=10)
+        self.estimator_mass_pub = rospy.Publisher('/graspSuccessEstimator/masses', Float64MultiArray, queue_size=10)
+
+    def ft_sensor_callback(self, data):
+        # TODO add a filter that averages a sliding window until all FT measurements in that window have a smaller
+        # variance than a predefined threshold value and the sliding window is completely filled up with messages.
+        self.last_ft_measurement = data
+
+    def ft_sensor_no_tool_callback(self, data):
+        last_ft_measurement = WrenchStamped()
+        last_ft_measurement.wrench.force.x = data.data[0]
+        last_ft_measurement.wrench.force.y = data.data[1]
+        last_ft_measurement.wrench.force.z = data.data[2]
+
+        last_ft_measurement.wrench.torque.x = data.data[3]
+        last_ft_measurement.wrench.torque.y = data.data[4]
+        last_ft_measurement.wrench.torque.z = data.data[5]
+
+        self.last_ft_measurement = last_ft_measurement
+
+    def ham_state_callback(self, data):
+        new_cm = data.executing_control_mode_name
+        if new_cm != self.active_cm:
+            self.active_cm = new_cm
+
+        #    print(new_cm)
+
+            if rospy.get_param("/graspSuccessEstimator/active", default=True):
+                if new_cm == 'ReferenceMassMeasurement':
+                    self.calculate_reference_mass()
+                elif new_cm == 'EstimationMassMeasurement':
+                    self.estimate_number_of_objects()
+            elif new_cm in ['ReferenceMassMeasurement', 'EstimationMassMeasurement']:
+                self.publish_status(RESPONSES.GRASP_SUCCESS_ESTIMATOR_INACTIVE)
+
+    def publish_status(self, status):
+        rospy.sleep(2.0)  # Otherwise windows side isn't quick enough to subscribe to topic. TODO find better solution?
+        self.estimator_status_pub.publish(status.value)
+
+    def to_base_frame(self, ft_measurement_msg):
+        try:
+            # transform ft sensor frame to world frame which makes it easy to identify the gravity component of
+            # the ft sensor values as the z-axis (ft_sensor_wrench is in ee frame)
+            (trans, rot) = self.tf_listener.lookupTransform('/base_link', '/ee', rospy.Time(0))
+
+            R = tf.transformations.quaternion_matrix(rot)
+            T = tf.transformations.translation_matrix(trans)
+            frame_transform = tf.transformations.concatenate_matrices(T, R)
+
+            ft_measurement = [ft_measurement_msg.wrench.force.x, ft_measurement_msg.wrench.force.y,
+                              ft_measurement_msg.wrench.force.z, 1]
+            # print("4", frame_transform, ft_measurement)
+            # print("4", type(frame_transform), type(ft_measurement))
+            return frame_transform.dot(ft_measurement)
+        except (tf.LookupException, tf.ConnectivityException, tf.ExtrapolationException):
+            print("Could not lookup transform from /ee to /base_link")
+            # TODO potentially add wait for transform (with timeout)
+            return None
+
+    def calculate_reference_mass(self):
+
+        self.current_object_name = rospy.get_param(self.object_ros_param_path, default=None)
+
+        # print("LAST FT MEASUREMENT", self.last_ft_measurement)
+        # TODO maybe add some kind of wait here to make sure the force/torque readings are stable (e.g. variance filter)
+        if self.last_ft_measurement is not None:
+
+            ft_in_base = self.to_base_frame(self.last_ft_measurement)
+            if ft_in_base is not None:
+                self.ft_measurement_reference = ft_in_base
+                self.reference_mass = MassEstimator.force2mass(ft_in_base[2])  # z-axis
+                print("Reference mass: {}".format(self.reference_mass))
+                self.publish_status(RESPONSES.REFERENCE_MEASUREMENT_SUCCESS)
+                self.estimator_mass_pub.publish(data=[self.reference_mass])
+                return
+
+        # In case we weren't able to calculate the reference mass, signal failure
+        self.ft_measurement_reference = None
+        self.publish_status(RESPONSES.REFERENCE_MEASUREMENT_FAILURE)
+
+    def estimate_number_of_objects(self):
+        if self.ft_measurement_reference is None:
+            rospy.logerr("No reference measurement is present.")
+            self.publish_status(RESPONSES.ESTIMATION_RESULT_UNKNOWN_FAILURE)
+            return  # failure
+
+        if self.current_object_name is None or self.current_object_name != rospy.get_param(self.object_ros_param_path,
+                                                                                           default=None):
+            rospy.logerr("The object name of the reference measurement doesn't match the one of the estimation.")
+            self.publish_status(RESPONSES.ESTIMATION_RESULT_UNKNOWN_FAILURE)
+            return  # failure
+
+        if self.current_object_name not in self.objects_info:
+
+            rospy.logwarn("The current object {0} does not have the required object mass parameter set. Skip it".format(
+                self.current_object_name))
+            self.publish_status(RESPONSES.GRASP_SUCCESS_ESTIMATOR_INACTIVE)
+            return  # ignore
+
+        # TODO maybe add some kind of wait here to make sure the force/torque readings are stable (e.g. variance filter)
+        # TODO one good way would be to refactor and move code to a ft getter method...
+        if self.last_ft_measurement is not None:
+            ft_in_base = self.to_base_frame(self.last_ft_measurement)
+            if ft_in_base is not None:
+                second_mass = MassEstimator.force2mass(ft_in_base[2])  # z-axis
+                mass_diff = second_mass - self.reference_mass
+
+                print("MASSES:", second_mass, self.reference_mass, " diff:", mass_diff)
+                print("FT_IN_BASE ref:", self.ft_measurement_reference)
+                print("FT_IN_BASE est:", ft_in_base)
+
+                object_mean = self.objects_info[self.current_object_name].mass_mean
+                object_stddev = self.objects_info[self.current_object_name].mass_stddev
+
+                max_pdf_val = -1.0
+                max_num_obj = -1
+                pdf_val_sum = 0.0
+                pdf_values = []
+                for num_obj in range(0, 5):  # classes (number of detected objects) we perform maximum likelihood on.
+                    pdf_val = norm.pdf(mass_diff, object_mean * num_obj, object_stddev)
+                    pdf_values.append(pdf_val)
+                    pdf_val_sum += pdf_val
+                    if pdf_val > max_pdf_val:
+                        max_pdf_val = pdf_val
+                        max_num_obj = num_obj
+
+                confidence = max_pdf_val / pdf_val_sum
+
+                if confidence < MassEstimator.CONFIDENCE_THRESHOLD:
+                    rospy.logwarn("Confidence ({0}) is very low! Mass diff was: {1}".format(confidence, mass_diff))
+
+                # publish the number of objects with the highest likelihood and the confidence
+                self.estimator_number_pub.publish(max_num_obj)
+                self.estimator_confidence_pub.publish(confidence)
+                confidence_all = map(lambda x: x / pdf_val_sum, pdf_values)
+                self.estimator_confidence_all_pub.publish(MassEstimator.list_to_Float64MultiArrayMsg(confidence_all))
+
+                # publish the estimated masses
+                self.estimator_mass_pub.publish(MassEstimator.list_to_Float64MultiArrayMsg(
+                    [self.reference_mass, second_mass]))
+
+                # publish the corresponding status message
+                if max_num_obj == 0:
+                    self.publish_status(RESPONSES.ESTIMATION_RESULT_NO_OBJECT)
+                elif max_num_obj == 1:
+                    self.publish_status(RESPONSES.ESTIMATION_RESULT_OKAY)
+                else:
+                    self.publish_status(RESPONSES.ESTIMATION_RESULT_TOO_MANY)
+                return  # success
+
+        # In case we weren't able to calculate the number of objects, signal failure
+        self.ft_measurement_reference = None
+        self.publish_status(RESPONSES.ESTIMATION_RESULT_UNKNOWN_FAILURE)
+
+
+if __name__ == '__main__':
+
+    my_argv = rospy.myargv(argv=sys.argv)
+    if len(my_argv) < 3:
+        print("usage: grasp_success_estimator.py object_ros_param_path path_to_object_parameters")
+    else:
+        we = MassEstimator(my_argv[1], my_argv[2])
+        rospy.spin()
+        # locking between the callbacks not required as long as we use only one spinner. See:
+        # https://answers.ros.org/question/48429/should-i-use-a-lock-on-resources-in-a-listener-node-with-multiple-callbacks/

--- a/ec_grasp_planner/src/handarm_parameters.py
+++ b/ec_grasp_planner/src/handarm_parameters.py
@@ -38,7 +38,7 @@ class BaseHandArm(dict):
         self.assertNoCopyMissing()
 
     def assertNoCopyMissing(self):
-        strategies = ['wall_grasp','edge_grasp','surface_grasp']
+        strategies = ['wall_grasp', 'edge_grasp', 'surface_grasp']
         for s, s_other in itertools.product(strategies, repeat=2):
             for k in self[s]:
                 for k_other in self[s_other]:

--- a/ec_grasp_planner/src/multi_object_params.py
+++ b/ec_grasp_planner/src/multi_object_params.py
@@ -26,9 +26,16 @@ def angle_between(v1, v2):
     v2_u = unit_vector(v2)
     return np.arccos(np.clip(np.dot(v1_u, v2_u), -1.0, 1.0))
 
+
 class multi_object_params:
-    def __init__(self, file_name = "object_param.yaml"):
+    def __init__(self, file_name="object_param.yaml"):
         self.file_name = file_name
+        self.data = None
+
+    def get_object_params(self):
+        if self.data is None:
+            self.load_object_params()
+        return self.data
 
     # ================================================================================================
     def transform_msg_to_homogenous_tf(self, msg):
@@ -38,10 +45,10 @@ class multi_object_params:
     ## --------------------------------------------------------- ##
     #load parameters for hand-object-strategy
     def load_object_params(self):
-        file = pkg_path + '/data/'+ self.file_name
+        file = pkg_path + '/data/' + self.file_name
         with open(file, 'r') as stream:
             try:
-                self.data =yaml.load(stream)
+                self.data = yaml.load(stream)
                 # print("data loaded {}".format(file))
             except yaml.YAMLError as exc:
                 print(exc)
@@ -74,7 +81,7 @@ class multi_object_params:
                 diff_angle = math.fabs(angle_between(obj_x_axis, ec_x_axis) - math.radians(val))
                 # print("obj_x = {}, ec_x = {}, eps = {}, optimalDeg = {}, copare = {}".format(
                 #     obj_x_axis, ec_x_axis, angle_epsilon, val, diff_angle))
-                if (diff_angle <= math.radians(angle_epsilon)):
+                if diff_angle <= math.radians(angle_epsilon):
                     q_val = success[idx]
                     break
             # if the angle was not within the given bounded sets
@@ -88,7 +95,7 @@ class multi_object_params:
 
         # distance form EC (wall end edge)
         # this is the tr from object_frame to ec_frame in object frame
-        if (strategy in ["WallGrasp", "EdgeGrasp"]):
+        if strategy in ["WallGrasp", "EdgeGrasp"]:
             delta = np.linalg.inv(ec_frame).dot(object_frame)
             # this is the distance between object and EC
             dist = delta[2, 3]
@@ -105,19 +112,18 @@ class multi_object_params:
         # the one on th right side of the robot
         # y coord is the smallest
 
-        if (all_ec_frames[current_ec_index][1,3] > 0):
+        if all_ec_frames[current_ec_index][1,3] > 0:
                 return 0
 
         min_y = 10000
-        min_y_index = 0;
-
+        min_y_index = 0
 
         for i, ec in enumerate(all_ec_frames):
             if min_y > ec[1,3]:
                 min_y = ec[1,3]
                 min_y_index = i
 
-        if (min_y_index == current_ec_index):
+        if min_y_index == current_ec_index:
             return 1
         else:
             return 0

--- a/ec_grasp_planner/src/planner.py
+++ b/ec_grasp_planner/src/planner.py
@@ -24,6 +24,8 @@ from numpy.random.mtrand import choice
 from tf import transformations as tra
 import numpy as np
 
+from grasp_success_estimator import RESPONSES
+
 from geometry_msgs.msg import PoseStamped
 from geometry_msgs.msg import Pose
 from geometry_msgs.msg import Point
@@ -46,6 +48,8 @@ from visualization_msgs.msg import Marker
 
 from pregrasp_msgs import srv as vision_srv
 
+from enum import Enum
+
 import pyddl
 
 import rospkg
@@ -63,7 +67,58 @@ import multi_object_params as mop
 markers_rviz = MarkerArray()
 frames_rviz = []
 
-class GraspPlanner():
+
+class FailureCases(Enum):
+    MASS_ESTIMATION_NO_OBJECT = 3
+    MASS_ESTIMATION_TOO_MANY = 4
+
+
+class Reaction:
+    def __init__(self, object_type, strategy, object_params):
+        self.label_to_cm = {
+            'REEXECUTE': 'failure_rerun_',
+            'REPLAN': 'failure_replan_',
+            'CONTINUE': None,  # depends on the non-failure case
+        }
+
+        # contains all failure cases that depend on the mass parameter
+        self.mass_depended = [FailureCases.MASS_ESTIMATION_NO_OBJECT, FailureCases.MASS_ESTIMATION_TOO_MANY]
+
+        self.reactions = {}
+        if 'reactions' in object_params[object_type][strategy]:
+            reaction_param = object_params[object_type][strategy]['reactions']
+            for rp in reaction_param:
+                self.reactions[FailureCases[rp.upper()]] = reaction_param[rp]
+
+        self.object_type = object_type
+        self.strategy = strategy
+        if 'mass' in object_params[object_type]:
+            self.mass = object_params[object_type]['mass']
+        else:
+            self.mass = None
+
+    def cm_name_for(self, failure_case, default):
+        if failure_case not in self.reactions:
+            raise KeyError("No reaction parameter set for {} ({}, {})".format(failure_case, self.object_type,
+                                                                              self.strategy))
+
+        if self.mass is None and failure_case in self.mass_depended:
+            raise ValueError("No mass parameter set for {} ({}, {})".format(failure_case, self.object_type,
+                                                                            self.strategy))
+
+        if self.label_to_cm[self.reactions[failure_case]] is None:
+            # There is no special (failure) control mode required (e.g. CONTINUE) return the default
+            return default
+
+        # return the name of the cm for the respective failure case
+        return self.label_to_cm[self.reactions[failure_case]] + str(failure_case.value)
+
+
+class GraspPlanner:
+
+    # maximum amount of time (in seconds) that the success estimator has for its measurements per control mode.
+    success_estimator_timeout = 10.0
+
     def __init__(self, args):
         # initialize the ros node
         rospy.init_node('ec_planner')
@@ -101,7 +156,7 @@ class GraspPlanner():
             raise rospy.ServiceException("handarm type not supported. Did you add {0} to handarm_parameters.py".format(
                 req.handarm_type))
 
-
+        # load hand arm parameters set in handarm_parameters.py
         self.handarm_params = handarm_parameters.__dict__[req.handarm_type]()
         # check if the handarm parameters aren't containing any contradicting information or bugs because of non-copying
         self.handarm_params.checkValidity()
@@ -210,7 +265,8 @@ class GraspPlanner():
         # --------------------------------------------------------
         # Turn grasp into hybrid automaton
         ha, self.rviz_frames = hybrid_automaton_from_motion_sequence(grasp_path, graph, graph_in_base, object_in_base,
-                                                                self.handarm_params, self.object_type)
+                                                                     self.handarm_params, self.object_type,
+                                                                     self.multi_object_handler.get_object_params())
 
         # --------------------------------------------------------
         # Output the hybrid automaton
@@ -238,13 +294,15 @@ class GraspPlanner():
 
 
 # ================================================================================================
-def create_surface_grasp(object_frame, support_surface_frame, handarm_params, object_type):
+def create_surface_grasp(object_frame, support_surface_frame, handarm_params, object_type, object_params):
 
     # Get the relevant parameters for hand object combination
     if object_type in handarm_params['surface_grasp']:
         params = handarm_params['surface_grasp'][object_type]
     else:
         params = handarm_params['surface_grasp']['object']
+
+    reaction = Reaction(object_type, 'SurfaceGrasp', object_params)
 
     hand_transform = params['hand_transform']
     pregrasp_transform = params['pregrasp_transform']
@@ -278,9 +336,6 @@ def create_surface_grasp(object_frame, support_surface_frame, handarm_params, ob
     # half the distance we want to achieve since we do two consecutive lifts
     dirUp_2 = tra.translation_matrix([0, 0, up_speed/2.0])
 
-    # The maximal time that the grasp success estimation is allowed to take.
-    success_estimator_timeout = 10.0  # in seconds
-
     # Set the frames to visualize with RViz
     rviz_frames = [object_frame, goal_, pre_grasp_pose]
 
@@ -295,38 +350,40 @@ def create_surface_grasp(object_frame, support_surface_frame, handarm_params, ob
     # # 1b. Switch when hand reaches the goal pose
     # control_sequence.append(ha.FramePoseSwitch('Pre_preGrasp', 'PreGrasp', controller='GoAboveIFCO', epsilon='0.01'))
 
-    # 2. Go above the object - PreGrasp
+    # 1. Go above the object - PreGrasp
     control_sequence.append(ha.InterpolatedHTransformControlMode(pre_grasp_pose,
                                                                  controller_name='GoAboveObject',
                                                                  goal_is_relative='0',
                                                                  name='PreGrasp',
                                                                  v_max=pre_grasp_velocity))
 
-    # 2b. Switch when hand reaches the goal pose
+    # 1b. Switch when hand reaches the goal pose
     control_sequence.append(ha.FramePoseSwitch('PreGrasp', 'ReferenceMassMeasurement', controller='GoAboveObject',
                                                epsilon='0.01'))
 
     # TODO add a time switch and short waiting time before the reference measurement is actually done?
-    # 3. Reference mass measurement with empty hand (TODO can this be replaced by offline calibration?)
+    # 2. Reference mass measurement with empty hand (TODO can this be replaced by offline calibration?)
     control_sequence.append(ha.BlockJointControlMode(name='ReferenceMassMeasurement'))  # TODO use gravity comp instead?
 
-    # 3b. Switches when reference measurement was done
-    # 3b.1 Successful reference measurement
+    # 2b. Switches when reference measurement was done
+    # 2b.1 Successful reference measurement
     control_sequence.append(ha.RosTopicSwitch('ReferenceMassMeasurement', 'GoDown',
                                               ros_topic_name='/graspSuccessEstimator/status', ros_topic_type='Float64',
-                                              goal=np.array([0.0]),  # 0.0 = REFERENCE_MEASUREMENT_SUCCESS
+                                              goal=np.array([RESPONSES.REFERENCE_MEASUREMENT_SUCCESS.value]),
                                               ))
 
-    # 3b.2 The grasp success estimator module is inactive
+    # 2b.2 The grasp success estimator module is inactive
     control_sequence.append(ha.RosTopicSwitch('ReferenceMassMeasurement', 'GoDown',
                                               ros_topic_name='/graspSuccessEstimator/status', ros_topic_type='Float64',
-                                              goal=np.array([99.0]),  # 99.0 = GRASP_SUCCESS_ESTIMATOR_INACTIVE
+                                              goal=np.array([RESPONSES.GRASP_SUCCESS_ESTIMATOR_INACTIVE.value]),
                                               ))
 
-    # 3b.3 Timeout (grasp success estimator module not started, an error occurred or it takes too long)
-    control_sequence.append(ha.TimeSwitch('ReferenceMassMeasurement', 'GoDown', duration=success_estimator_timeout))
+    # 2b.3 Timeout (grasp success estimator module not started, an error occurred or it takes too long)
+    control_sequence.append(ha.TimeSwitch('ReferenceMassMeasurement', 'GoDown',
+                                          duration=GraspPlanner.success_estimator_timeout))
 
-    # TODO add switch for actual error response (estimator signals REFERENCE_MEASUREMENT_FAILURE)?
+    # 2b.4 There is no special switch for unknown error response (estimator signals REFERENCE_MEASUREMENT_FAILURE)
+    #      Instead the timeout will trigger giving the user an opportunity to notice the erroneous result in the GUI.
 
     # 3. Go down onto the object (relative in world frame) - Godown
     control_sequence.append(
@@ -353,8 +410,16 @@ def create_surface_grasp(object_frame, support_surface_frame, handarm_params, ob
                                                  port='2'))
 
     # 4. Maintain the position
-    desired_displacement = np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 0.0, 1.0]])
-    force_gradient = np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0], [0.0, 0.0, 1.0, 0.005], [0.0, 0.0, 0.0, 1.0]])
+    desired_displacement = np.array([[1.0, 0.0, 0.0, 0.0],
+                                     [0.0, 1.0, 0.0, 0.0],
+                                     [0.0, 0.0, 1.0, 0.0],
+                                     [0.0, 0.0, 0.0, 1.0]])
+
+    force_gradient = np.array([[1.0, 0.0, 0.0, 0.0],
+                               [0.0, 1.0, 0.0, 0.0],
+                               [0.0, 0.0, 1.0, 0.005],
+                               [0.0, 0.0, 0.0, 1.0]])
+
     desired_force_dimension = np.array([0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
 
     if handarm_params['isForceControllerAvailable']:
@@ -390,51 +455,63 @@ def create_surface_grasp(object_frame, support_surface_frame, handarm_params, ob
     control_sequence.append(ha.BlockJointControlMode(name='EstimationMassMeasurement'))
 
     # 7b. Switches after estimation measurement was done
+    target_cm_okay = 'GoUp_2'
 
     # 7b.1 No object was grasped => go to failure mode.
-    #      Since it is a surface grasp we might still be able to simple re-run the plan
-    control_sequence.append(ha.RosTopicSwitch('EstimationMassMeasurement', 'failure_rerun_3',
+    target_cm_estimation_no_object = reaction.cm_name_for(FailureCases.MASS_ESTIMATION_NO_OBJECT, default=target_cm_okay)
+    control_sequence.append(ha.RosTopicSwitch('EstimationMassMeasurement', target_cm_estimation_no_object,
                                               ros_topic_name='/graspSuccessEstimator/status', ros_topic_type='Float64',
-                                              goal=np.array([10.0]),  # 10.0 = ESTIMATION_RESULT_NO_OBJECT
+                                              goal=np.array([RESPONSES.ESTIMATION_RESULT_NO_OBJECT.value]),
                                               ))
 
-    # 7b.2 More than one object was grasped => failure (re-running plan, won't help since too many objects were moved)
-    control_sequence.append(ha.RosTopicSwitch('EstimationMassMeasurement', 'failure_replan_3',
+    # 7b.2 More than one object was grasped => failure
+    target_cm_estimation_too_many = reaction.cm_name_for(FailureCases.MASS_ESTIMATION_TOO_MANY, default=target_cm_okay)
+    control_sequence.append(ha.RosTopicSwitch('EstimationMassMeasurement', target_cm_estimation_too_many,
                                               ros_topic_name='/graspSuccessEstimator/status', ros_topic_type='Float64',
-                                              goal=np.array([12.0]),  # 12.0 = ESTIMATION_RESULT_TO_MANY
+                                              goal=np.array([RESPONSES.ESTIMATION_RESULT_TOO_MANY.value]),
                                               ))
 
     # 7b.3 Exactly one object was grasped => success (continue lifting the object and go to drop off)
-    control_sequence.append(ha.RosTopicSwitch('EstimationMassMeasurement', 'GoUp_2',
+    control_sequence.append(ha.RosTopicSwitch('EstimationMassMeasurement', target_cm_okay,
                                               ros_topic_name='/graspSuccessEstimator/status', ros_topic_type='Float64',
-                                              goal=np.array([11.0]),  # 11.0 = ESTIMATION_RESULT_OKAY
+                                              goal=np.array([RESPONSES.ESTIMATION_RESULT_OKAY.value]),
                                               ))
 
     # 7b.4 The grasp success estimator module is inactive => directly continue lifting the object and go to drop off
-    control_sequence.append(ha.RosTopicSwitch('EstimationMassMeasurement', 'GoUp_2',
+    control_sequence.append(ha.RosTopicSwitch('EstimationMassMeasurement', target_cm_okay,
                                               ros_topic_name='/graspSuccessEstimator/status', ros_topic_type='Float64',
-                                              goal=np.array([99.0]),  # 99.0 = GRASP_SUCCESS_ESTIMATOR_INACTIVE
+                                              goal=np.array([RESPONSES.GRASP_SUCCESS_ESTIMATOR_INACTIVE.value]),
                                               ))
 
     # 7b.5 Timeout (grasp success estimator module not started, an error occurred or it takes too long)
-    control_sequence.append(ha.TimeSwitch('EstimationMassMeasurement', 'GoUp_2', duration=success_estimator_timeout))
+    control_sequence.append(ha.TimeSwitch('EstimationMassMeasurement', target_cm_okay,
+                                          duration=GraspPlanner.success_estimator_timeout))
 
-    # TODO add switch for actual error response (estimator signals ESTIMATION_RESULT_UNKNOWN_FAILURE)?
+    # 7b.6 There is no special switch for unknown error response (estimator signals ESTIMATION_RESULT_UNKNOWN_FAILURE)
+    #      Instead the timeout will trigger giving the user an opportunity to notice the erroneous result in the GUI.
 
     # 8. After estimation measurement control modes.
-    # 8.1 Failure control mode representing grasping failure, which might be corrected by re-running the plan.
-    control_sequence.append(ha.GravityCompensationMode(name='failure_rerun_3'))
+    extra_failure_cms = set()
+    if target_cm_estimation_no_object != target_cm_okay:
+        extra_failure_cms.add(target_cm_estimation_no_object)
+    if target_cm_estimation_too_many != target_cm_okay:
+        extra_failure_cms.add(target_cm_estimation_too_many)
 
-    # 8.2 Failure control mode representing grasping failure, which can't be corrected and requires to re-plan.
-    control_sequence.append(ha.GravityCompensationMode(name='failure_replan_3'))
+    for cm in extra_failure_cms:
+        if cm.startswith('failure_rerun'):
+            # 8.1 Failure control mode representing grasping failure, which might be corrected by re-running the plan.
+            control_sequence.append(ha.GravityCompensationMode(name=cm))
+        if cm.startswith('failure_replan'):
+            # 8.2 Failure control mode representing grasping failure, which can't be corrected and requires to re-plan.
+            control_sequence.append(ha.GravityCompensationMode(name=cm))
 
     # 8.3 Success control mode. Lift hand even further
     control_sequence.append(ha.InterpolatedHTransformControlMode(dirUp_2, controller_name='GoUpHTransform',
-                                                                 name='GoUp_2', goal_is_relative='1',
+                                                                 name=target_cm_okay, goal_is_relative='1',
                                                                  reference_frame="world"))
 
     # 8.3b Switch when joint configuration is reached
-    control_sequence.append(ha.FramePoseSwitch('GoUp_2', 'GoDropOff', controller='GoUpHTransform', epsilon='0.01',
+    control_sequence.append(ha.FramePoseSwitch(target_cm_okay, 'GoDropOff', controller='GoUpHTransform', epsilon='0.01',
                                                goal_is_relative='1', reference_frame="world"))
 
     # 9. Go to dropOFF location
@@ -442,7 +519,8 @@ def create_surface_grasp(object_frame, support_surface_frame, handarm_params, ob
                                                 name='GoDropOff'))
 
     # 9.b  Switch when joint is reached
-    control_sequence.append(ha.JointConfigurationSwitch('GoDropOff', 'finished', controller = 'GoToDropJointConfig', epsilon = str(math.radians(7.))))
+    control_sequence.append(ha.JointConfigurationSwitch('GoDropOff', 'finished', controller = 'GoToDropJointConfig',
+                                                        epsilon=str(math.radians(7.))))
 
     # 10. Block joints to finish motion and hold object in air
     control_sequence.append(ha.BlockJointControlMode(name='finished'))
@@ -451,13 +529,15 @@ def create_surface_grasp(object_frame, support_surface_frame, handarm_params, ob
 
 
 # ================================================================================================
-def create_wall_grasp(object_frame, support_surface_frame, wall_frame, handarm_params, object_type):
+def create_wall_grasp(object_frame, support_surface_frame, wall_frame, handarm_params, object_type, object_params):
 
     # Get the parameters from the handarm_parameters.py file
     if (object_type in handarm_params['wall_grasp']):
         params = handarm_params['wall_grasp'][object_type]
     else:
         params = handarm_params['wall_grasp']['object']
+
+    reaction = Reaction(object_type, 'WallGrasp', object_params)
 
     # initial configuration above IFCO. Should be easy to go from here to pregrasp pose
     # TODO remove this once we have configuration space planning capabilities
@@ -527,9 +607,34 @@ def create_wall_grasp(object_frame, support_surface_frame, wall_frame, handarm_p
                                              name="PreGrasp"))
 
     # 1b. Switch when hand reaches the goal pose
-    control_sequence.append(ha.FramePoseSwitch('PreGrasp', 'GoDown', controller='GoAboveObject', epsilon='0.01'))
+    control_sequence.append(ha.FramePoseSwitch('PreGrasp', 'ReferenceMassMeasurement', controller='GoAboveObject',
+                                               epsilon='0.01'))
 
-    # 2. Go down onto the object/table, in world frame
+    # TODO add a time switch and short waiting time before the reference measurement is actually done?
+    # 2. Reference mass measurement with empty hand (TODO can this be replaced by offline calibration?)
+    control_sequence.append(ha.BlockJointControlMode(name='ReferenceMassMeasurement'))  # TODO use gravity comp instead?
+
+    # 2b. Switches when reference measurement was done
+    # 2b.1 Successful reference measurement
+    control_sequence.append(ha.RosTopicSwitch('ReferenceMassMeasurement', 'GoDown',
+                                              ros_topic_name='/graspSuccessEstimator/status', ros_topic_type='Float64',
+                                              goal=np.array([RESPONSES.REFERENCE_MEASUREMENT_SUCCESS.value]),
+                                              ))
+
+    # 2b.2 The grasp success estimator module is inactive
+    control_sequence.append(ha.RosTopicSwitch('ReferenceMassMeasurement', 'GoDown',
+                                              ros_topic_name='/graspSuccessEstimator/status', ros_topic_type='Float64',
+                                              goal=np.array([RESPONSES.GRASP_SUCCESS_ESTIMATOR_INACTIVE.value]),
+                                              ))
+
+    # 2b.3 Timeout (grasp success estimator module not started, an error occurred or it takes too long)
+    control_sequence.append(ha.TimeSwitch('ReferenceMassMeasurement', 'GoDown',
+                                          duration=GraspPlanner.success_estimator_timeout))
+
+    # 2b.4 There is no special switch for unknown error response (estimator signals REFERENCE_MEASUREMENT_FAILURE)
+    #      Instead the timeout will trigger giving the user an opportunity to notice the erroneous result in the GUI.
+
+    # 3. Go down onto the object/table, in world frame
     dirDown = tra.translation_matrix([0, 0, -down_dist])
     control_sequence.append(
         ha.InterpolatedHTransformControlMode(dirDown,
@@ -539,7 +644,7 @@ def create_wall_grasp(object_frame, support_surface_frame, wall_frame, handarm_p
                                              reference_frame="world",
                                              v_max=go_down_velocity))
 
-    # 2b. Switch when force threshold is exceeded
+    # 3b. Switch when force threshold is exceeded
     force = np.array([0, 0, downward_force, 0, 0, 0])
     control_sequence.append(ha.ForceTorqueSwitch('GoDown',
                                                  'LiftHand',
@@ -550,19 +655,19 @@ def create_wall_grasp(object_frame, support_surface_frame, wall_frame, handarm_p
                                                  frame_id='world',
                                                  port='2'))
 
-    # TODO: remove 3 and 3b if hand should slide on surface
+    # TODO: remove 4 and 4b if hand should slide on surface
     # OR duration=0.0
-    # 3. Lift upwards so the hand doesn't slide on table surface
+    # 4. Lift upwards so the hand doesn't slide on table surface
     dirLift = tra.translation_matrix([0, 0, lift_dist])
     control_sequence.append(
         ha.InterpolatedHTransformControlMode(dirLift, controller_name='Lift1', goal_is_relative='1', name="LiftHand",
                                              reference_frame="world"))
 
-    # 3b. We switch after a short time as this allows us to do a small, precise lift motion
+    # 4b. We switch after a short time as this allows us to do a small, precise lift motion
     # TODO partners: this can be replaced by a frame pose switch if your robot is able to do small motions precisely
     control_sequence.append(ha.TimeSwitch('LiftHand', 'SlideToWall', duration=0.2))
 
-    # 4. Go towards the wall to slide object to wall
+    # 5. Go towards the wall to slide object to wall
     dirWall = tra.translation_matrix([0, 0, -sliding_dist])
     #TODO sliding_distance should be computed from wall and hand frame.
 
@@ -573,16 +678,18 @@ def create_wall_grasp(object_frame, support_surface_frame, wall_frame, handarm_p
                                              name="SlideToWall", reference_frame="world",
                                              v_max=slide_velocity))
 
-    # 4b. Switch when the f/t sensor is triggered with normal force from wall
+    # 5b. Switch when the f/t sensor is triggered with normal force from wall
     # TODO arne: needs tuning
     force = np.array([0, 0, wall_force, 0, 0, 0])
-    mode_name_hand_closing = 'softhand_close_2'  # the 2 represents a wall grasp. This way the strategy is encoded in the HA.
+    # the 2 in softhand_close_2 represents a wall grasp. This way the strategy is encoded in the HA.
+    mode_name_hand_closing = 'softhand_close_2'
+
     control_sequence.append(ha.ForceTorqueSwitch('SlideToWall', mode_name_hand_closing, 'ForceSwitch', goal=force,
                                                  norm_weights=np.array([0, 0, 1, 0, 0, 0]),
                                                  jump_criterion="THRESH_UPPER_BOUND", goal_is_relative='1',
                                                  frame_id='world', frame=wall_frame, port='2'))
 
-    # 5. Maintain contact while closing the hand
+    # 6. Maintain contact while closing the hand
     if handarm_params['isForceControllerAvailable']:
         # apply force on object while closing the hand
         # TODO arne: validate these values
@@ -599,62 +706,129 @@ def create_wall_grasp(object_frame, support_surface_frame, wall_frame, handarm_p
         # just close the hand
         control_sequence.append(ha.close_rbohand())
 
-    # 5b. Switch when hand closing duration ends
+    # 6b. Switch when hand closing duration ends
     control_sequence.append(ha.TimeSwitch(mode_name_hand_closing, 'PostGraspRotate', duration=hand_closing_duration))
 
-    # 6. Move hand after closing and before lifting it up
+    # 7. Move hand after closing and before lifting it up
     # relative to current hand pose
     control_sequence.append(
         ha.HTransformControlMode(post_grasp_transform, controller_name='PostGraspRotate', name='PostGraspRotate',
                                  goal_is_relative='1', ))
 
-    # 6b. Switch when hand reaches post grasp pose
-    control_sequence.append(ha.FramePoseSwitch('PostGraspRotate', 'GoUp', controller='PostGraspRotate', epsilon='0.01',
-                                               goal_is_relative='1', reference_frame='EE'))
+    # 7b. Switch when hand reaches post grasp pose
+    control_sequence.append(ha.FramePoseSwitch('PostGraspRotate', 'GoUp_1', controller='PostGraspRotate',
+                                               epsilon='0.01', goal_is_relative='1', reference_frame='EE'))
 
-    # 7. Lift upwards (+z in world frame)
-    dirUp = tra.translation_matrix([0, 0, up_dist])
-    control_sequence.append(
-        ha.InterpolatedHTransformControlMode(dirUp, controller_name='GoUpHTransform', name='GoUp', goal_is_relative='1',
-                                             reference_frame="world"))
+    # 8. Lift upwards (+z in world frame)
+    # half the distance we want to achieve since we do two consecutive lifts
+    dir_up_2 = tra.translation_matrix([0, 0, up_dist / 2.0])
 
-    # 7b. Switch when lifting motion is completed
-    control_sequence.append(
-        ha.FramePoseSwitch('GoUp', 'GoDropOff', controller='GoUpHTransform', epsilon='0.01', goal_is_relative='1',
-                           reference_frame="world"))
+    control_sequence.append(ha.InterpolatedHTransformControlMode(dir_up_2, controller_name='GoUpHTransform',
+                                                                 name='GoUp_1', goal_is_relative='1',
+                                                                 reference_frame="world"))
 
-    # 8. Go to drop off configuration
+    # 8b. Switch when joint configuration (half way up) is reached
+    control_sequence.append(ha.FramePoseSwitch('GoUp_1', 'EstimationMassMeasurement', controller='GoUpHTransform',
+                                               epsilon='0.01', goal_is_relative='1', reference_frame="world"))
+
+    # 9. Measure the mass again and estimate number of grasped objects (grasp success estimation)
+    control_sequence.append(ha.BlockJointControlMode(name='EstimationMassMeasurement'))
+
+    # 9b. Switches after estimation measurement was done
+    target_cm_okay = 'GoUp_2'
+
+    # 9b.1 No object was grasped => go to failure mode.
+    target_cm_estimation_no_object = reaction.cm_name_for(FailureCases.MASS_ESTIMATION_NO_OBJECT,
+                                                          default=target_cm_okay)
+    control_sequence.append(ha.RosTopicSwitch('EstimationMassMeasurement', target_cm_estimation_no_object,
+                                              ros_topic_name='/graspSuccessEstimator/status', ros_topic_type='Float64',
+                                              goal=np.array([RESPONSES.ESTIMATION_RESULT_NO_OBJECT.value]),
+                                              ))
+
+    # 9b.2 More than one object was grasped => failure
+    target_cm_estimation_too_many = reaction.cm_name_for(FailureCases.MASS_ESTIMATION_TOO_MANY, default=target_cm_okay)
+    control_sequence.append(ha.RosTopicSwitch('EstimationMassMeasurement', target_cm_estimation_too_many,
+                                              ros_topic_name='/graspSuccessEstimator/status', ros_topic_type='Float64',
+                                              goal=np.array([RESPONSES.ESTIMATION_RESULT_TOO_MANY.value]),
+                                              ))
+
+    # 9b.3 Exactly one object was grasped => success (continue lifting the object and go to drop off)
+    control_sequence.append(ha.RosTopicSwitch('EstimationMassMeasurement', target_cm_okay,
+                                              ros_topic_name='/graspSuccessEstimator/status', ros_topic_type='Float64',
+                                              goal=np.array([RESPONSES.ESTIMATION_RESULT_OKAY.value]),
+                                              ))
+
+    # 9b.4 The grasp success estimator module is inactive => directly continue lifting the object and go to drop off
+    control_sequence.append(ha.RosTopicSwitch('EstimationMassMeasurement', target_cm_okay,
+                                              ros_topic_name='/graspSuccessEstimator/status', ros_topic_type='Float64',
+                                              goal=np.array([RESPONSES.GRASP_SUCCESS_ESTIMATOR_INACTIVE.value]),
+                                              ))
+
+    # 9b.5 Timeout (grasp success estimator module not started, an error occurred or it takes too long)
+    control_sequence.append(ha.TimeSwitch('EstimationMassMeasurement', target_cm_okay,
+                                          duration=GraspPlanner.success_estimator_timeout))
+
+    # 9b.6 There is no special switch for unknown error response (estimator signals ESTIMATION_RESULT_UNKNOWN_FAILURE)
+    #      Instead the timeout will trigger giving the user an opportunity to notice the erroneous result in the GUI.
+
+    # 10. After estimation measurement control modes.
+    extra_failure_cms = set()
+    if target_cm_estimation_no_object != target_cm_okay:
+        extra_failure_cms.add(target_cm_estimation_no_object)
+    if target_cm_estimation_too_many != target_cm_okay:
+        extra_failure_cms.add(target_cm_estimation_too_many)
+
+    for cm in extra_failure_cms:
+        if cm.startswith('failure_rerun'):
+            # 10.1 Failure control mode representing grasping failure, which might be corrected by re-running the plan.
+            control_sequence.append(ha.GravityCompensationMode(name=cm))
+        if cm.startswith('failure_replan'):
+            # 10.2 Failure control mode representing grasping failure, which can't be corrected and requires to re-plan.
+            control_sequence.append(ha.GravityCompensationMode(name=cm))
+
+    # 10.3 Success control mode. Lift hand even further
+    control_sequence.append(ha.InterpolatedHTransformControlMode(dir_up_2, controller_name='GoUpHTransform',
+                                                                 name=target_cm_okay, goal_is_relative='1',
+                                                                 reference_frame="world"))
+
+    # 10.3b Switch when joint configuration is reached
+    control_sequence.append(ha.FramePoseSwitch(target_cm_okay, 'GoDropOff', controller='GoUpHTransform', epsilon='0.01',
+                                               goal_is_relative='1', reference_frame="world"))
+
+    # 11. Go to drop off configuration
     control_sequence.append(
         ha.JointControlMode(drop_off_config, controller_name='GoToDropJointConfig', name='GoDropOff'))
 
-    # 8.b  Switch when configuration is reached
+    # 11.b Switch when configuration is reached
     control_sequence.append(ha.JointConfigurationSwitch('GoDropOff', 'finished', controller='GoToDropJointConfig',
                                                         epsilon=str(math.radians(7.))))
 
-    # 9. Block joints to finish motion and hold object in air
-    finishedMode = ha.ControlMode(name='finished')
-    finishedSet = ha.ControlSet()
-    finishedSet.add(ha.Controller(name='JointSpaceController', type='JointController', goal=np.zeros(7),
-                                  goal_is_relative=1, v_max='[0,0]', a_max='[0,0]'))
-    finishedMode.set(finishedSet)
-    control_sequence.append(finishedMode)
+    # 12. Block joints to finish motion and hold object in air
+    control_sequence.append(ha.BlockJointControlMode(name='finished'))
 
     return cookbook.sequence_of_modes_and_switches_with_safety_features(control_sequence), rviz_frames
 
-# ================================================================================================
-def transform_msg_to_homogenous_tf(msg):
-    return np.dot(tra.translation_matrix([msg.translation.x, msg.translation.y, msg.translation.z]), tra.quaternion_matrix([msg.rotation.x, msg.rotation.y, msg.rotation.z, msg.rotation.w]))
 
 # ================================================================================================
-def homogenous_tf_to_pose_msg(htf):
-    return Pose(position = Point(*tra.translation_from_matrix(htf).tolist()), orientation = Quaternion(*tra.quaternion_from_matrix(htf).tolist()))
+def transform_msg_to_homogeneous_tf(msg):
+    return np.dot(tra.translation_matrix([msg.translation.x, msg.translation.y, msg.translation.z]),
+                  tra.quaternion_matrix([msg.rotation.x, msg.rotation.y, msg.rotation.z, msg.rotation.w]))
+
+
+# ================================================================================================
+def homogeneous_tf_to_pose_msg(htf):
+    return Pose(position=Point(*tra.translation_from_matrix(htf).tolist()),
+                orientation=Quaternion(*tra.quaternion_from_matrix(htf).tolist()))
+
 
 # ================================================================================================
 def get_node_from_actions(actions, action_name, graph):
     return graph.nodes[[int(m.sig[1][1:]) for m in actions if m.name == action_name][0]]
 
+
 # ================================================================================================
-def hybrid_automaton_from_motion_sequence(motion_sequence, graph, T_robot_base_frame, T_object_in_base, handarm_params, object_type):
+def hybrid_automaton_from_motion_sequence(motion_sequence, graph, T_robot_base_frame, T_object_in_base, handarm_params,
+                                          object_type, object_params):
     assert(len(motion_sequence) > 1)
     assert(motion_sequence[-1].name.startswith('grasp'))
 
@@ -663,24 +837,27 @@ def hybrid_automaton_from_motion_sequence(motion_sequence, graph, T_robot_base_f
 
     print("Creating hybrid automaton for object {} and grasp type {}.".format(object_type, grasp_type))
     if grasp_type == 'EdgeGrasp':
-        raise "Edge grasp is not supported yet"
+        raise ValueError("Edge grasp is not supported yet")
         #support_surface_frame_node = get_node_from_actions(motion_sequence, 'move_object', graph)
         #support_surface_frame = T_robot_base_frame.dot(transform_msg_to_homogenous_tf(support_surface_frame_node.transform))
         #edge_frame_node = get_node_from_actions(motion_sequence, 'grasp_object', graph)
         #edge_frame = T_robot_base_frame.dot(transform_msg_to_homogenous_tf(edge_frame_node.transform))
-        return create_edge_grasp(T_object_in_base, support_surface_frame, edge_frame, handarm_params)
+        return create_edge_grasp(T_object_in_base, support_surface_frame, edge_frame, handarm_params, object_type,
+                                 object_params)
     elif grasp_type == 'WallGrasp':
         support_surface_frame_node = get_node_from_actions(motion_sequence, 'move_object', graph)
-        support_surface_frame = T_robot_base_frame.dot(transform_msg_to_homogenous_tf(support_surface_frame_node.transform))
+        support_surface_frame = T_robot_base_frame.dot(transform_msg_to_homogeneous_tf(support_surface_frame_node.transform))
         wall_frame_node = get_node_from_actions(motion_sequence, 'grasp_object', graph)
-        wall_frame = T_robot_base_frame.dot(transform_msg_to_homogenous_tf(wall_frame_node.transform))
-        return create_wall_grasp(T_object_in_base, support_surface_frame, wall_frame, handarm_params, object_type)
+        wall_frame = T_robot_base_frame.dot(transform_msg_to_homogeneous_tf(wall_frame_node.transform))
+        return create_wall_grasp(T_object_in_base, support_surface_frame, wall_frame, handarm_params, object_type,
+                                 object_params)
     elif grasp_type == 'SurfaceGrasp':
         support_surface_frame_node = get_node_from_actions(motion_sequence, 'grasp_object', graph)
-        support_surface_frame = T_robot_base_frame.dot(transform_msg_to_homogenous_tf(support_surface_frame_node.transform))
-        return create_surface_grasp(T_object_in_base, support_surface_frame, handarm_params, object_type)
+        support_surface_frame = T_robot_base_frame.dot(transform_msg_to_homogeneous_tf(support_surface_frame_node.transform))
+        return create_surface_grasp(T_object_in_base, support_surface_frame, handarm_params, object_type, object_params)
     else:
-        raise "Unknown grasp type: ", grasp_type
+        raise ValueError("Unknown grasp type: {}".format(grasp_type))
+
 
 # ================================================================================================
 def find_a_path(hand_start_node_id, object_start_node_id, graph, goal_node_list, verbose = False):
@@ -769,6 +946,7 @@ def find_a_path(hand_start_node_id, object_start_node_id, graph, goal_node_list,
 
     return plan
 
+
 # ================================================================================================
 def publish_rviz_markers(frames, frame_id, handarm_params):
 
@@ -793,7 +971,7 @@ def publish_rviz_markers(frames, frame_id, handarm_params):
         msg.mesh_resource = handarm_params["mesh_file"]
         msg.scale.x = msg.scale.y = msg.scale.z = handarm_params["mesh_file_scale"]
         #msg.mesh_resource = mesh_resource
-        msg.pose = homogenous_tf_to_pose_msg(f)
+        msg.pose = homogeneous_tf_to_pose_msg(f)
 
         markers_rviz.markers.append(msg)
 
@@ -810,12 +988,14 @@ def publish_rviz_markers(frames, frame_id, handarm_params):
         msg.color.r = msg.color.a = 1
         msg.scale.x = 0.01 # shaft diameter
         msg.scale.y = 0.03 # head diameter
-        msg.points.append(homogenous_tf_to_pose_msg(f1).position)
-        msg.points.append(homogenous_tf_to_pose_msg(f2).position)
+        msg.points.append(homogeneous_tf_to_pose_msg(f1).position)
+        msg.points.append(homogeneous_tf_to_pose_msg(f2).position)
 
         markers_rviz.markers.append(msg)
 
     frames_rviz = frames
+
+
 # ================================================================================================
 if __name__ == '__main__':
 
@@ -838,7 +1018,7 @@ if __name__ == '__main__':
     # parser.add_argument('--handarm', type=str, default = 'RBOHand2WAM',
     #                     help='Python class that contains configuration parameters for hand and arm-specific properties.')
     parser.add_argument('--object_params_file', type=str, default='object_param.yaml',
-                        help='Name of the file containing parameters for object-EC selection when multiple objects are present')
+                        help='Name of the file containing object specific parameters (e.g. for object-EC selection when multiple objects are present)')
 
     # args = parser.parse_args()
     args = parser.parse_args(rospy.myargv()[1:])

--- a/ec_grasp_planner/src/planner.py
+++ b/ec_grasp_planner/src/planner.py
@@ -97,7 +97,16 @@ class Reaction:
         else:
             self.mass = None
 
+    # returns true iff no reaction was defined at all
+    def is_no_reaction(self):
+        return not self.reactions  # reactions is not empty
+
     def cm_name_for(self, failure_case, default):
+
+        if self.is_no_reaction():
+            # No reactions defined => there is no special (failure) control mode => return the default CM
+            return default
+
         if failure_case not in self.reactions:
             raise KeyError("No reaction parameter set for {} ({}, {})".format(failure_case, self.object_type,
                                                                               self.strategy))


### PR DESCRIPTION
This PR together with https://github.com/SoMa-Project/soma_utils/pull/133 fixes issues https://github.com/SoMa-Project/soma_utils/issues/115.
And thus make use of the reactive behavior introduced in PR https://github.com/SoMa-Project/soma_utils/pull/127.
To get details on re-plan and re-run see description here https://github.com/SoMa-Project/soma_utils/issues/119.

This PR introduces the grasp success estimator (using the FT-Sensor to estimate mass) into the planner.

### Estimator interface
The estimator is a separate ros node and provides the following interface: 
- If the current control mode (topic: `/ham_state`) switches to `ReferenceMassMeasurement` the grasp success estimator will perform a reference mass measurement (empty hand). 
    - It will signal the completion if that task on the topic `/graspSuccessEstimator/status` via a status code.
    - It will also publish an array containing one element (the reference mass) to the topic `/graspSuccessEstimator/masses`
- If the current control mode  (topic: `/ham_state`) switches to `EstimationMassMeasurement` the grasp success estimator will measure the mass again and compare it to it's reference measurement.
    - It will signal the completion of that task on the same topic as before `/graspSuccessEstimator/status` via a status code.
    - In case the status code corresponds to a result (no object, one object, more than one object) it also publishes it's confidence (`/graspSuccessEstimator/confidence` and `/graspSuccessEstimator/confidence_all`) and the estimated number of objects (`/graspSuccessEstimator/num_objects`)
    -  It will also publish an array containing two elements (the reference mass, the estimation mass) to the topic `/graspSuccessEstimator/masses`
- To launch the node you'll need to provide four parameters. The launch file `grasp_succes_estimator.launch` in `soma_utils/planner_gui/launch/` provides default arguments and is the best place to customize the system to different setups.
    1. `ft_topic_name`: Name of the FT-Topic to use. The force/torque values are supposed to be in **EE** frame. **It is important to set the mass values in the object parameter file accordingly.**  
         _E.g. At RBO the topic /ft_notool already accounts for the weight of the EE (recommended), whereas /ft_sensor_wrench does not._ 
    2. `ft_topic_type`: The message type of the FT-Topic. Currently supported are: 
        - Float64MultiArray [force_x, force_y, force_z, torque_x, torque_y, torque_z] 
        - WrenchStamped (make sure it is in EE frame)
    3. `object_ros_param_path`: The name of the ros parameter than contains the name of the current object (usually: `/planner_gui/object`)
    4. `path_to_object_parameters`: The location of the yaml file that contains the required mass information (usually: `data/object_param.yaml`)

For a description of the status codes look at the enum `class RESPONSES` implemented in `grasp_success_estimator.py`.

### Planner integration
The planner incorporates the grasp success estimator for SurfaceGrasps and WallGrasps in the following way:
- Before the CM `GoDown` it will go into `ReferenceMassMeasurement`
- The old CM GoUp was splitted into two halfs. In between the planner will go into  `EstimationMassMeasurement`. 
    - The reason behind this is, that we want to get the estimation measurement as early as possible but after the object was at least lifted a little.
    - The planner will add up to five reactions (depending on the config file) to the result of the estimator's result:
        1. [Result=okay] switch to GoUp (second part) and continue grasp pipeline
        2. [Result=no_object] switch to replan, rerun, GoUp (depending on config)
        3. [Result=too_many] switch to replan, rerun, GoUp (depending on config)
        4. [Result=inactive] switch to GoUp (second part) and continue grasp pipeline
        5. [Result=timeout] switch to GoUp (second part) and continue grasp pipeline after timeout

### Configuration
The reactive behavior can be configured on an per-object basis using the file `data/object_param.yaml`
The attributes that have to be set are `reactions` and `mass`
- reactions (list of pair: result <-> reaction)
     - Implementation in classes `FailureCases` and `Reaction` in `planner.py`
     - currently supported reactions are: 
         - CONTINUE (simply continue the grasp pipeline)
         - REPLAN (stops current grasp and allows to re-plan from view position)
         - RERUN (stops current grasp and allows to re-run the last plan again)
- mass (parameters for gaussian distribution model describing the mass of the object to be grasped units are kg)
- If no reaction is given at all the default is CONTINUE otherwise an error is thrown if a parameter is missing.

An example can be seen here:
```
  mango:
    SurfaceGrasp: 
      success: 1.0
      min: [-0.14, -0.1]
      max: [0.14, 0.05]
      reactions: 
        mass_estimation_no_object: REPLAN
        mass_estimation_too_many: REPLAN
    WallGrasp: 
      success: 1.0
      min: [-1000.0, -0.075]
      max: [-0.05, 0.045]
      reactions: 
        mass_estimation_no_object: REPLAN
        mass_estimation_too_many: REPLAN
    EdgeGrasp: {'success': 0}
    mass: {'mean': 0.28052, 'stddev': 0.05958}
```

### Testing the PR
_Most of the content of this PR was tested on bottom-3 using the full system. Details as follow:_
- SurfaceGrasp + Wallgrasp tested
- Estimation result tested: no object + exactly one object 
- reactions tested: success, re-plan, re-run (using a slightly older version that shouldn't differ too much)

_Further tests wouldn't hurt_

**Note:** 
This PR also includes an update to the submodule hybrid-automaton-tools-py. It might make sense to merge these changes into the actual reopsitory (See: https://gitlab.tubit.tu-berlin.de/rbo-lab/hybrid-automaton-tools-py/merge_requests/3)


