### PR TITLE
Include naming fix of commit  4fae5d7 

### DIFF
--- a/ec_grasp_planner/src/RBOHandRecipesWAM.py
+++ b/ec_grasp_planner/src/RBOHandRecipesWAM.py
@@ -89,12 +89,12 @@ def create_surface_grasp(chosen_object, handarm_params, pregrasp_transform, alte
     control_sequence.append(ha.TimeSwitch('softhand_preshape_1_1', 'PreGrasp', duration=0.2))
 
     # 2. Go above the object - PreGrasp
-    if alternative_behavior is not None and 'pre_grasp' in alternative_behavior:
+    if alternative_behavior is not None and 'pre_approach' in alternative_behavior:
 
         # we can not use the initially generated plan, but have to include the result of the feasibility checks
-        goal_traj = alternative_behavior['pre_grasp'].get_trajectory()
+        goal_traj = alternative_behavior['pre_approach'].get_trajectory()
 
-        print("Use alternative GOAL_TRAJ PreGrasp Dim", goal_traj.shape)
+        print("Use alternative GOAL_TRAJ PreApproach Dim", goal_traj.shape)
         control_sequence.append(ha.JointControlMode(goal_traj, name='PreGrasp', controller_name='GoAboveObject',
                                                     goal_is_relative='0',
                                                     v_max=pre_grasp_joint_velocity,
@@ -344,12 +344,12 @@ def create_wall_grasp(chosen_object, wall_frame, handarm_params, pregrasp_transf
     control_sequence.append(ha.TimeSwitch('softhand_preshape_2_1', 'PreGrasp', duration=0.5))
 
     # 2. Go above the object - Pregrasp
-    if alternative_behavior is not None and 'pre_grasp' in alternative_behavior:
+    if alternative_behavior is not None and 'pre_approach' in alternative_behavior:
 
         # we can not use the initially generated plan, but have to include the result of the feasibility checks
-        goal_traj = alternative_behavior['pre_grasp'].get_trajectory()
+        goal_traj = alternative_behavior['pre_approach'].get_trajectory()
 
-        print("Use alternative GOAL_TRAJ PreGrasp Dim", goal_traj.shape)
+        print("Use alternative GOAL_TRAJ PreApproach Dim", goal_traj.shape)
         control_sequence.append(ha.JointControlMode(goal_traj, name='PreGrasp', controller_name='GoAboveObject',
                                                     goal_is_relative='0',
                                                     v_max=pre_grasp_joint_velocity,
@@ -690,11 +690,11 @@ def create_corner_grasp(chosen_object, corner_frame_alpha_zero, handarm_params, 
     control_sequence.append(ha.TimeSwitch('softhand_preshape_4_1', 'PreGrasp', duration=0.5))  # time for pre-shape
 
     # 2. Go above the object - Pregrasp
-    if alternative_behavior is not None and 'pre_grasp' in alternative_behavior:
+    if alternative_behavior is not None and 'pre_approach' in alternative_behavior:
         # we can not use the initially generated plan, but have to include the result of the feasibility checks
-        goal_traj = alternative_behavior['pre_grasp'].get_trajectory()
+        goal_traj = alternative_behavior['pre_approach'].get_trajectory()
 
-        print("Use alternative GOAL_TRAJ PreGrasp Dim", goal_traj.shape)
+        print("Use alternative GOAL_TRAJ PreApproach Dim", goal_traj.shape)
         control_sequence.append(ha.JointControlMode(goal_traj, name='PreGrasp', controller_name='GoAboveObject',
                                                     goal_is_relative='0',
                                                     v_max=pre_grasp_joint_velocity,


### PR DESCRIPTION
From: https://github.com/SoMa-Project/ec_grasp_planner/issues/58

```
> somehow the alternative_behavior does not have a field pre_grasp but pre_approach. Where can this naming difference come from?

This is probably a result from the merge in which at some point pre_grasp was renamed pre_approach in handarm_parameters and thus to avoid introducing the old name again (because of the new parameters) I had to change it in the feasibility node as well
This is surprising, because I thought I already changed it, but it does not appear to be in the commit... Whatever, the fix is easy. Just change 'pre_grasp' to 'pre_approach' for alternative_behavior
I'll also commit a fix in a second to the branch tub_ocado_merge_full
```

This PR merges the fix into master to make the checker usable!